### PR TITLE
Missing Sorcerer Spells - Level 3

### DIFF
--- a/_posts/2015-07-30-water-breathing.markdown
+++ b/_posts/2015-07-30-water-breathing.markdown
@@ -5,7 +5,7 @@ date:   2015-07-30
 tags: [sorcerer, wizard, druid, ranger, level2]
 ---
 
-**3rd-Ievel transmutation (ritual)**
+**3rd-Level transmutation (ritual)**
 
 **Casting Time**: 1 action
 

--- a/_posts/2015-07-30-water-breathing.markdown
+++ b/_posts/2015-07-30-water-breathing.markdown
@@ -1,0 +1,18 @@
+---
+layout: post
+title:  "Water Breathing"
+date:   2015-07-30
+tags: [sorcerer, wizard, druid, ranger, level2]
+---
+
+**3rd-Ievel transmutation (ritual)**
+
+**Casting Time**: 1 action
+
+**Range**: 30 feet
+
+**Components**: V, S, M (a short reed or piece of straw)
+
+**Duration**: 24 hours
+
+This spell grants up to ten willing creatures you can see within range the abilily to breathe underwater until the spell ends. Affected creatures also retain their normal mode of respiration.

--- a/_posts/2015-07-30-water-walk.markdown
+++ b/_posts/2015-07-30-water-walk.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Water Walk"
 date:   2015-07-30
-tags: [sorcerer, wizard, druid, ranger, level2]
+tags: [sorcerer, cleric, druid, ranger, level2]
 ---
 
 **3rd-Level transmutation (ritual)**

--- a/_posts/2015-07-30-water-walk.markdown
+++ b/_posts/2015-07-30-water-walk.markdown
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  "Water Walk"
+date:   2015-07-30
+tags: [sorcerer, wizard, druid, ranger, level2]
+---
+
+**3rd-Level transmutation (ritual)**
+
+**Casting Time**: 1 action
+
+**Range**: 30 feet
+
+**Components**: V, S, M (a piece of cork)
+
+**Duration**: 1 hours
+
+This spell grants the ability to move across any liquid surface-such as water, acid, mud, snow, quicksand, or lava-as if it were harmless solid ground (creatures crossing molten lava can still take damage from the heal). Up to ten willing creatures you can see within range gain this abilily for the duration.
+
+lf you target a creature submerged in a liquid, the spell carries the target to the surface of the liquid at a rate of 60 feet per round.


### PR DESCRIPTION
Added the missing Water Walk and Water Breathing spells to the set.