### PR TITLE
Add cantrips from Sword Coast Adventurer's Guide

### DIFF
--- a/_posts/2015-12-07-booming-blade.markdown
+++ b/_posts/2015-12-07-booming-blade.markdown
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  "Booming Blade"
+date:   2015-12-07
+tags: [sorcerer, warlock, wizard, cantrip]
+---
+
+**Evocation cantrip**
+
+**Casting Time**: 1 action
+
+**Range**: 5 feet
+
+**Components**: V, M (a weapon)
+
+**Duration**: 1 round
+
+As part of the action used to cast this spell, you must make a melee attack with a weapon against one creature within the spell's range, otherwise the spell fails. On a hit, the target suffers the attack's normal effects, and it becomes sheathed in booming energy until the start of your next turn. If the target willingly moves before then, it immediately takes 1d8 thunder damage, and the spell ends.
+
+This spell's damage increases when you reach higher levels. At 5th level, the melee attack deals an extra 1d8 thunder damage to the target, and the damage the target takes for moving increases to 2d8. Both damage rolls increase by 1d8 at 11th level and 17th level.

--- a/_posts/2015-12-07-green-flame-blade.markdown
+++ b/_posts/2015-12-07-green-flame-blade.markdown
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  "Green-Flame Blade"
+date:   2015-12-07
+tags: [sorcerer, warlock, wizard, cantrip]
+---
+
+**Evocation cantrip**
+
+**Casting Time**: 1 action
+
+**Range**: 5 feet
+
+**Components**: V, M (a weapon)
+
+**Duration**: Instantaneous
+
+As part of the action used to cast this spell, you must make a melee attack with a weapon against one creature within the spell's range, otherwise the spell fails. On a hit, the target suffers the attack's normal effects, and green fire leaps from the target to a different creature of your choice that you can see within 5 feet of it. The second creature takes fire damage equal to your spellcasting modifier.
+
+This spell's damage increases when you reach higher levels. At 5th level, the melee attack deals an extra 1d8 fire damage to the target, and the fire damage to the second creature increases to 1d8 + your spellcasting ability modifier. Both damage rolls increase by 1d8 at 11th level and 17th level. 

--- a/_posts/2015-12-07-lightning-lure.markdown
+++ b/_posts/2015-12-07-lightning-lure.markdown
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  "Lightning Lure"
+date:   2015-12-07
+tags: [sorcerer, warlock, wizard, cantrip]
+---
+
+**Evocation cantrip**
+
+**Casting Time**: 1 action
+
+**Range**: 15 feet
+
+**Components**: V
+
+**Duration**: Instantaneous
+
+You create a lash of lightning energy that strikes at one creature of your choice that you can see within range. The target must succeed on a Strength saving throw or be pulled up to 10 feet in a straight line toward you and then take 1d8 lightning damage if it is within 5 feet of you.
+
+This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).

--- a/_posts/2015-12-07-sword-burst.markdown
+++ b/_posts/2015-12-07-sword-burst.markdown
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  "Sword Burst"
+date:   2015-12-07
+tags: [sorcerer, warlock, wizard, cantrip]
+---
+
+**Conjuration cantrip**
+
+**Casting Time**: 1 action
+
+**Range**: 5 feet
+
+**Components**: V
+
+**Duration**: Instantaneous
+
+You create a momentary circle of spectral blades that sweep around you. Each creature within range, other than you, must succeed on a Dexterity saving throw or take 1d6 force damage.
+
+This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).


### PR DESCRIPTION
These are all four of the spells added in the SCAG supplementary book.