### PR TITLE
Feature/schools [wip]

### DIFF
--- a/_data/schools.yml
+++ b/_data/schools.yml
@@ -1,0 +1,16 @@
+- name: Abjuration
+  tag: abjuration
+- name: Conjuration
+  tag: conjuration
+- name: Divination
+  tag: divination
+- name: Enchantment
+  tag: enchantment
+- name: Evocation
+  tag: evocation
+- name: Illusion
+  tag: illusion
+- name: Necromancy
+  tag: necromancy
+- name: Transmutation
+  tag: transmutaion

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,8 +21,54 @@
     		}
   		}
 
+        function schoolClick(e) {
+            var schools = Array.prototype.slice.call(document.querySelectorAll('.spell-school:not([name="all"])')),
+                selected = e.target,
+                tags = [];
+
+            if (selected.nodeName !== 'A') return;
+            if (selected.name == 'all') {
+                selected.classList.add('selected');
+                schools.forEach(function(school) {
+                    school.classList.remove('selected');
+                });
+            }
+            else {
+                document.querySelector('.spell-school[name="all"]').classList.remove('selected');
+                selected.classList.toggle('selected');
+                tags = Array.prototype.slice.call(document.querySelectorAll('.spell-school.selected')).map(function(el) { return el.name; });
+            }
+
+            filterSpells(tags);
+        }
+
+        /**
+         * Hide/show spells based on presence of at least one of the given tags.
+         */
+        function filterSpells(tags) {
+            var spells = document.querySelectorAll('.post-list li'),
+                selector,
+                unselected
+
+            // Start by making previously hidden spells visible again
+            // (this does not conflict with jets search filtering)
+            Array.prototype.slice.call(spells).forEach(function(spell) {
+                spell.style.display = '';
+            });
+
+            if (tags.length == 0) return;
+
+            // Hide all spells where all of the given tags are not present
+            selector = tags.map(function(tag) { return ':not([tags~="' + tag + '"])'; });
+            unselected = document.querySelectorAll('.post-list .post-link' + selector.join(''));
+            Array.prototype.slice.call(unselected).forEach(function(spell) {
+                spell.parentNode.style.display = 'none';
+            });
+        }
+
   		window.onload = function(){
         document.getElementById("menuIcon").addEventListener( 'click' , menuClick );
+        document.querySelector(".schools-list").addEventListener( 'click', schoolClick );
 	    }
     </script>
 </head>

--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -18,6 +18,17 @@
 				</dd>
 				{% endfor %}
 			</dl>
+			<dl class="schools-list">
+				<dt>Spell schools:</dt>
+					<dd>
+						<a class="spell-school selected" name="all">All</a>
+					</dd> |
+					{% for spellSchool in site.data.schools %}
+					<dd>
+						<a class="spell-school" name="{{ spellSchool.tag }}">{{ spellSchool.name }}</a>
+					</dd>
+					{% endfor %}
+			</dl>
 
 			{% for level in site.data.levels %}
 			<a id="{{level.tag}}"></a>
@@ -28,7 +39,7 @@
 			{% if tag == page.tag %}
 			<ul class="post-list jetsContent">
 				<li>
-					<a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+					<a class="post-link" tags="{{ post.tags | join " "}}" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
 				</li>
 			</ul>
 			{% endif %}

--- a/_posts/2014-08-24-alarm.markdown
+++ b/_posts/2014-08-24-alarm.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Alarm"
 date:   2014-08-24
-tags: [ranger, wizard, level1]
+tags: [ranger, wizard, level1, abjuration]
 ---
 
 **1st-level abjuration (ritual)**

--- a/_posts/2014-08-24-animal-friendship.markdown
+++ b/_posts/2014-08-24-animal-friendship.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Animal Friendship"
 date:   2014-08-24
-tags: [bard, druid, ranger, level1]
+tags: [bard, druid, ranger, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-armor-of-agathys.markdown
+++ b/_posts/2014-08-24-armor-of-agathys.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Armor of Agathys"
 date:   2014-08-24
-tags: [warlock, level1]
+tags: [warlock, level1, abjuration]
 ---
 
 **1st-level abjuration**

--- a/_posts/2014-08-24-arms-of-hadar.markdown
+++ b/_posts/2014-08-24-arms-of-hadar.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Arms of Hadar"
 date:   2014-08-24
-tags: [warlock, level1]
+tags: [warlock, level1, conjuration]
 ---
 
 **1st-level conjuration**

--- a/_posts/2014-08-24-bane.markdown
+++ b/_posts/2014-08-24-bane.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Bane"
 date:   2014-08-24
-tags: [bard, cleric, level1]
+tags: [bard, cleric, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-bless.markdown
+++ b/_posts/2014-08-24-bless.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Bless"
 date:   2014-08-24
-tags: [cleric, paladin, level1]
+tags: [cleric, paladin, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-burning-hands.markdown
+++ b/_posts/2014-08-24-burning-hands.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Burning Hands"
 date:   2014-08-24
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-charm-person.markdown
+++ b/_posts/2014-08-24-charm-person.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Charm Person"
 date:   2014-08-24
-tags: [bard, cleric (trickery), druid, sorcerer, warlock, wizard, level1]
+tags: [bard, cleric (trickery), druid, sorcerer, warlock, wizard, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-chromatic-orb.markdown
+++ b/_posts/2014-08-24-chromatic-orb.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Chromatic Orb"
 date:   2014-08-24
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-color-spray.markdown
+++ b/_posts/2014-08-24-color-spray.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Color Spray"
 date:   2014-08-24
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, illusion]
 ---
 
 **1st-level illusion**

--- a/_posts/2014-08-24-command.md
+++ b/_posts/2014-08-24-command.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Command"
 date:   2014-08-24
-tags: [cleric, paladin, level1]
+tags: [cleric, paladin, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-compelled-duel.markdown
+++ b/_posts/2014-08-24-compelled-duel.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Compelled Duel"
 date:   2014-08-24
-tags: [paladin, level1]
+tags: [paladin, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-comprehend-languages.markdown
+++ b/_posts/2014-08-24-comprehend-languages.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Comprehend Languages"
 date:   2014-08-24
-tags: [bard, sorcerer, warlock, wizard, level1]
+tags: [bard, sorcerer, warlock, wizard, level1, divination]
 ---
 
 **1st-level divination (ritual)**

--- a/_posts/2014-08-24-create-or-destroy-water.markdown
+++ b/_posts/2014-08-24-create-or-destroy-water.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Create or Destroy Water"
 date:   2014-08-24
-tags: [cleric, druid, level1]
+tags: [cleric, druid, level1, transmutation]
 ---
 
 **1st-level transmutation**

--- a/_posts/2014-08-24-cure-wounds.markdown
+++ b/_posts/2014-08-24-cure-wounds.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Cure Wounds"
 date:   2014-08-24
-tags: [bard, cleric, druid, paladin, ranger, level1]
+tags: [bard, cleric, druid, paladin, ranger, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-detect-evil-and-good.markdown
+++ b/_posts/2014-08-24-detect-evil-and-good.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Detect Evil and Good"
 date:   2014-08-24
-tags: [cleric, paladin, level1]
+tags: [cleric, paladin, level1, divination]
 ---
 
 **1st-level divination**

--- a/_posts/2014-08-24-detect-magic.markdown
+++ b/_posts/2014-08-24-detect-magic.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Detect Magic"
 date:   2014-08-24
-tags: [bard, cleric, druid, paladin, ranger, sorcerer, wizard, level1]
+tags: [bard, cleric, druid, paladin, ranger, sorcerer, wizard, level1, divination]
 ---
 
 **1st-level divination (ritual)**

--- a/_posts/2014-08-24-detect-poison-or-disease.markdown
+++ b/_posts/2014-08-24-detect-poison-or-disease.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Detect Poison or Disease"
 date:   2014-08-24
-tags: [cleric, druid, paladin, ranger, level1]
+tags: [cleric, druid, paladin, ranger, level1, divination]
 ---
 
 **1st-level divination (ritual)**

--- a/_posts/2014-08-24-disguise-self.markdown
+++ b/_posts/2014-08-24-disguise-self.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Disguise Self"
 date:   2014-08-24
-tags: [bard, cleric (trickery), sorcerer, wizard, level1]
+tags: [bard, cleric (trickery), sorcerer, wizard, level1, illusion]
 ---
 
 **1st-level illusion**

--- a/_posts/2014-08-24-dissonant-whispers.markdown
+++ b/_posts/2014-08-24-dissonant-whispers.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Dissonant Whispers"
 date:   2014-08-24
-tags: [bard, level1]
+tags: [bard, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-divine-favor.markdown
+++ b/_posts/2014-08-24-divine-favor.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Divine Favor"
 date:   2014-08-24
-tags: [paladin, level1]
+tags: [paladin, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-ensnaring-strike.markdown
+++ b/_posts/2014-08-24-ensnaring-strike.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Ensnaring Strike"
 date:   2014-08-24
-tags: [ranger, level1]
+tags: [ranger, level1, conjuration]
 ---
 
 **1st-level conjuration**

--- a/_posts/2014-08-24-entangle.markdown
+++ b/_posts/2014-08-24-entangle.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Entangle"
 date:   2014-08-24
-tags: [druid, level1]
+tags: [druid, level1, conjuration]
 ---
 
 **1st-level conjuration**

--- a/_posts/2014-08-24-expeditious-retreat.markdown
+++ b/_posts/2014-08-24-expeditious-retreat.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Expeditious Retreat"
 date:   2014-08-24
-tags: [sorcerer, warlock, wizard, level1]
+tags: [sorcerer, warlock, wizard, level1, transmutation]
 ---
 
 **1st-level transmutation**

--- a/_posts/2014-08-24-faerie-fire.markdown
+++ b/_posts/2014-08-24-faerie-fire.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Faerie Fire"
 date:   2014-08-24
-tags: [bard, druid, level1]
+tags: [bard, druid, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-false-life.markdown
+++ b/_posts/2014-08-24-false-life.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "False Life"
 date:   2014-08-24
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, necromancy]
 ---
 
 **1st-level necromancy**

--- a/_posts/2014-08-24-feather-fall.markdown
+++ b/_posts/2014-08-24-feather-fall.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Feather Fall"
 date:   2014-08-24
-tags: [bard, sorcerer, wizard, level1]
+tags: [bard, sorcerer, wizard, level1, transmutation]
 ---
 
 **1st-level transmutation**

--- a/_posts/2014-08-24-find-familiar.markdown
+++ b/_posts/2014-08-24-find-familiar.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Find Familiar"
 date:   2014-08-24
-tags: [wizard, level1]
+tags: [wizard, level1, conjuration]
 ---
 
 **1st-level conjuration (ritual)**

--- a/_posts/2014-08-24-fog-cloud.markdown
+++ b/_posts/2014-08-24-fog-cloud.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Fog Cloud"
 date:   2014-08-24
-tags: [druid, ranger, sorcerer, wizard, level1]
+tags: [druid, ranger, sorcerer, wizard, level1, conjuration]
 ---
 
 **1st-level conjuration**

--- a/_posts/2014-08-24-goodberry.markdown
+++ b/_posts/2014-08-24-goodberry.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Goodberry"
 date:   2014-08-24
-tags: [druid, ranger, level1]
+tags: [druid, ranger, level1, transmutation]
 ---
 
 **1st-level transmutation**

--- a/_posts/2014-08-24-grease.markdown
+++ b/_posts/2014-08-24-grease.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Grease"
 date:   2014-08-24
-tags: [wizard, level1]
+tags: [wizard, level1, conjuration]
 ---
 
 **1st-level conjuration**

--- a/_posts/2014-08-24-guiding-bolt.md
+++ b/_posts/2014-08-24-guiding-bolt.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Guiding Bolt"
 date:   2014-08-24
-tags: [cleric, level1]
+tags: [cleric, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-hail-of-thorns.markdown
+++ b/_posts/2014-08-24-hail-of-thorns.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Hail of Thorns"
 date:   2014-08-24
-tags: [ranger, level1]
+tags: [ranger, level1, conjuration]
 ---
 
 **1st-level conjuration**

--- a/_posts/2014-08-24-healing-word.md
+++ b/_posts/2014-08-24-healing-word.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Healing Word"
 date:   2014-08-24
-tags: [bard, cleric, druid, level1]
+tags: [bard, cleric, druid, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-hellish-rebuke.markdown
+++ b/_posts/2014-08-24-hellish-rebuke.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Hellish Rebuke"
 date:   2014-08-24
-tags: [warlock, level1]
+tags: [warlock, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-heroism.markdown
+++ b/_posts/2014-08-24-heroism.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Heroism"
 date:   2014-08-24
-tags: [bard, paladin, level1]
+tags: [bard, paladin, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-hex.markdown
+++ b/_posts/2014-08-24-hex.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Hex"
 date:   2014-08-24
-tags: [warlock, level1]
+tags: [warlock, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-hunters-mark.markdown
+++ b/_posts/2014-08-24-hunters-mark.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Hunter's Mark"
 date:   2014-08-24
-tags: [ranger, level1]
+tags: [ranger, level1, divination]
 ---
 
 **1st-level divination**

--- a/_posts/2014-08-24-identify.markdown
+++ b/_posts/2014-08-24-identify.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Identify"
 date:   2014-08-24
-tags: [bard, wizard, level1]
+tags: [bard, wizard, level1, divination]
 ---
 
 **1st-level divination (ritual)**

--- a/_posts/2014-08-24-illusory-script.markdown
+++ b/_posts/2014-08-24-illusory-script.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Illusory Script"
 date:   2014-08-24
-tags: [bard, warlock, wizard, level1]
+tags: [bard, warlock, wizard, level1, illusion]
 ---
 
 **1st-level illusion (ritual)**

--- a/_posts/2014-08-24-inflict-wounds.md
+++ b/_posts/2014-08-24-inflict-wounds.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Inflict Wounds"
 date:   2014-08-24
-tags: [cleric, level1]
+tags: [cleric, level1, necromancy]
 ---
 
 **1st-level necromancy**

--- a/_posts/2014-08-24-jump.markdown
+++ b/_posts/2014-08-24-jump.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Jump"
 date:   2014-08-24
-tags: [druid, ranger, sorcerer, wizard, level1]
+tags: [druid, ranger, sorcerer, wizard, level1, transmutation]
 ---
 
 **1st-level transmutation**

--- a/_posts/2014-08-24-longstrider.markdown
+++ b/_posts/2014-08-24-longstrider.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Longstrider"
 date:   2014-08-24
-tags: [bard, druid, ranger, wizard, level1]
+tags: [bard, druid, ranger, wizard, level1, transmutation]
 ---
 
 **1st-level transmutation**

--- a/_posts/2014-08-24-mage-armor.markdown
+++ b/_posts/2014-08-24-mage-armor.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Mage Armor"
 date:   2014-08-24
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, abjuration]
 ---
 
 **1st-level abjuration**

--- a/_posts/2014-08-24-magic-missile.markdown
+++ b/_posts/2014-08-24-magic-missile.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Magic Missile"
 date:   2014-08-24
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-minor-illusion.markdown
+++ b/_posts/2014-08-24-minor-illusion.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Minor Illusion"
 date:   2014-08-24
-tags: [bard, sorcerer, warlock, wizard, cantrip]
+tags: [bard, sorcerer, warlock, wizard, cantrip, illusion]
 ---
 
 **Illusion cantrip**

--- a/_posts/2014-08-24-protection-from-evil-and-good.markdown
+++ b/_posts/2014-08-24-protection-from-evil-and-good.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Protection from Evil and Good"
 date:   2014-08-24
-tags: [cleric, paladin, warlock, wizard, level1]
+tags: [cleric, paladin, warlock, wizard, level1, abjuration]
 ---
 
 **1st-level abjuration**

--- a/_posts/2014-08-24-purify-food-and-drink.markdown
+++ b/_posts/2014-08-24-purify-food-and-drink.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Purify Food and Drink"
 date:   2014-08-24
-tags: [cleric, druid, paladin, level1]
+tags: [cleric, druid, paladin, level1, transmutation]
 ---
 
 **1st-level transmutation**

--- a/_posts/2014-08-24-ray-of-sickness.markdown
+++ b/_posts/2014-08-24-ray-of-sickness.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Ray of Sickness"
 date:   2014-08-24
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, necromancy]
 ---
 
 **1st-level necromancy**

--- a/_posts/2014-08-24-remove-curse.markdown
+++ b/_posts/2014-08-24-remove-curse.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Remove Curse"
 date:   2014-08-24
-tags: [cleric, paladin, warlock, wizard, level3]
+tags: [cleric, paladin, warlock, wizard, level3, abjuration]
 ---
 
 **3rd-level abjuration**

--- a/_posts/2014-08-24-sanctuary.md
+++ b/_posts/2014-08-24-sanctuary.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Sanctuary"
 date:   2014-08-24
-tags: [cleric, level1]
+tags: [cleric, level1, abjuration]
 ---
 
 **1st-level abjuration**

--- a/_posts/2014-08-24-searing-smite.markdown
+++ b/_posts/2014-08-24-searing-smite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Searing Smite"
 date:   2014-08-24
-tags: [paladin, level1]
+tags: [paladin, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-shield-of-faith.md
+++ b/_posts/2014-08-24-shield-of-faith.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Shield of Faith"
 date: 2014-08-24
-tags: [cleric, paladin, level1]
+tags: [cleric, paladin, level1, abjuration]
 
 ---
 

--- a/_posts/2014-08-24-shield.markdown
+++ b/_posts/2014-08-24-shield.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Shield"
 date:   2014-08-24
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, abjuration]
 ---
 
 **1st-level abjuration**

--- a/_posts/2014-08-24-silent-image.markdown
+++ b/_posts/2014-08-24-silent-image.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Silent Image"
 date:   2014-08-24
-tags: [bard, sorcerer, wizard, level1]
+tags: [bard, sorcerer, wizard, level1, illusion]
 ---
 
 **1st-level illusion**

--- a/_posts/2014-08-24-sleep.markdown
+++ b/_posts/2014-08-24-sleep.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Sleep"
 date:   2014-08-24
-tags: [bard, sorcerer, wizard, level1]
+tags: [bard, sorcerer, wizard, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-speak-with-animals.markdown
+++ b/_posts/2014-08-24-speak-with-animals.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Speak with Animals"
 date:   2014-08-24
-tags: [bard, druid, ranger, level1]
+tags: [bard, druid, ranger, level1, divination]
 ---
 
 **1st-level divination (ritual)**

--- a/_posts/2014-08-24-tashas-hideous-laughter.md
+++ b/_posts/2014-08-24-tashas-hideous-laughter.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Tasha's Hideous Laughter"
 date:   2014-08-24
-tags: [bard, wizard, level1]
+tags: [bard, wizard, level1, enchantment]
 ---
 
 **1st-level enchantment**

--- a/_posts/2014-08-24-tensers-floating-disk.markdown
+++ b/_posts/2014-08-24-tensers-floating-disk.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Tenser's Floating Disk"
 date:   2014-08-24
-tags: [wizard, level1]
+tags: [wizard, level1, conjuration]
 ---
 
 **1st-level conjuration (ritual)**

--- a/_posts/2014-08-24-thunderous-smite.markdown
+++ b/_posts/2014-08-24-thunderous-smite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Thunderous Smite"
 date:   2014-08-24
-tags: [paladin, level1]
+tags: [paladin, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-thunderwave.markdown
+++ b/_posts/2014-08-24-thunderwave.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Thunderwave"
 date:   2014-08-24
-tags: [bard, druid, sorcerer, wizard, level1]
+tags: [bard, druid, sorcerer, wizard, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-unseen-servant.markdown
+++ b/_posts/2014-08-24-unseen-servant.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Unseen Servant"
 date:   2014-08-24
-tags: [bard, warlock, wizard, level1]
+tags: [bard, warlock, wizard, level1, conjuration]
 ---
 
 **1st-level conjuration (ritual)**

--- a/_posts/2014-08-24-vicious-mockery.markdown
+++ b/_posts/2014-08-24-vicious-mockery.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Vicious Mockery"
 date:   2014-08-24
-tags: [bard, cantrip]
+tags: [bard, cantrip, enchantment]
 ---
 
 **Enchantment cantrip**

--- a/_posts/2014-08-24-witch-bolt.markdown
+++ b/_posts/2014-08-24-witch-bolt.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Witch Bolt"
 date:   2014-08-24
-tags: [sorcerer, warlock, wizard, level1]
+tags: [sorcerer, warlock, wizard, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-08-24-wrathful-smite.markdown
+++ b/_posts/2014-08-24-wrathful-smite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Wrathful Smite"
 date:   2014-08-24
-tags: [paladin, level1]
+tags: [paladin, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2014-12-31-aid.md
+++ b/_posts/2014-12-31-aid.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Aid"
 date:   2014-12-31
-tags: [cleric, paladin, level2]
+tags: [cleric, paladin, level2, abjuration]
 ---
 
 **2nd-level abjuration**

--- a/_posts/2014-12-31-animal-messenger.markdown
+++ b/_posts/2014-12-31-animal-messenger.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Animal Messenger"
 date:   2014-12-31
-tags: [bard, druid, ranger, level2]
+tags: [bard, druid, ranger, level2, enchantment]
 ---
 
 **2nd-level enchantment (ritual)**

--- a/_posts/2014-12-31-augury.md
+++ b/_posts/2014-12-31-augury.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Augury"
 date:   2014-12-31
-tags: [cleric, level2]
+tags: [cleric, level2, divination]
 ---
 
 **2nd-level divination (ritual)**

--- a/_posts/2014-12-31-blindnessdeafness.markdown
+++ b/_posts/2014-12-31-blindnessdeafness.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Blindness/Deafness"
 date:   2014-12-31
-tags: [bard, cleric, sorcerer, wizard, level2]
+tags: [bard, cleric, sorcerer, wizard, level2, necromancy]
 ---
 
 **2nd-level necromancy**

--- a/_posts/2014-12-31-calm-emotions.markdown
+++ b/_posts/2014-12-31-calm-emotions.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Calm Emotions"
 date:   2014-12-31
-tags: [bard, cleric, level2]
+tags: [bard, cleric, level2, enchantment]
 ---
 
 **2nd-level enchantment**

--- a/_posts/2014-12-31-hold-person.md
+++ b/_posts/2014-12-31-hold-person.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Hold Person"
 date:   2014-12-31
-tags: [bard, cleric, druid, sorcerer, warlock, wizard, level2]
+tags: [bard, cleric, druid, sorcerer, warlock, wizard, level2, divination]
 ---
 
 **2nd-level divination (ritual)**

--- a/_posts/2014-12-31-lesser-restoration.markdown
+++ b/_posts/2014-12-31-lesser-restoration.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Lesser Restoration"
 date:   2014-12-31
-tags: [bard, cleric, druid, paladin, ranger, level2]
+tags: [bard, cleric, druid, paladin, ranger, level2, abjuration]
 ---
 
 **2nd-level abjuration**

--- a/_posts/2014-12-31-prayer-of-healing.markdown
+++ b/_posts/2014-12-31-prayer-of-healing.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Prayer of Healing"
 date:   2014-12-31
-tags: [cleric, level2]
+tags: [cleric, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2014-12-31-silence.markdown
+++ b/_posts/2014-12-31-silence.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Silence"
 date:   2014-12-31
-tags: [bard, cleric, ranger, level2]
+tags: [bard, cleric, ranger, level2, illusion]
 ---
 
 **2nd-level illusion (ritual)**

--- a/_posts/2014-12-31-spiritual-weapon.markdown
+++ b/_posts/2014-12-31-spiritual-weapon.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Spiritual Weapon"
 date:   2014-12-31
-tags: [cleric, level2]
+tags: [cleric, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2014-12-31-warding-bond.md
+++ b/_posts/2014-12-31-warding-bond.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Warding Bond"
 date:   2014-12-31
-tags: [cleric, level2]
+tags: [cleric, level2, abjuration]
 ---
 
 **2nd-level abjuration**

--- a/_posts/2015-01-01-animate-dead.markdown
+++ b/_posts/2015-01-01-animate-dead.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Animate Dead"
 date:   2015-01-01
-tags: [cleric, wizard, level3]
+tags: [cleric, wizard, level3, necromancy]
 ---
 
 **3rd-level necromancy**

--- a/_posts/2015-01-01-arcane-eye.markdown
+++ b/_posts/2015-01-01-arcane-eye.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Arcane Eye"
 date:   2015-01-01
-tags: [wizard, level4]
+tags: [wizard, level4, divination]
 ---
 
 **4th-level divination**

--- a/_posts/2015-01-01-aura-of-life.markdown
+++ b/_posts/2015-01-01-aura-of-life.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Aura of Life"
 date:   2015-01-01
-tags: [paladin, level4]
+tags: [paladin, level4, abjuration]
 ---
 
 **4th-level abjuration**

--- a/_posts/2015-01-01-aura-of-purity.markdown
+++ b/_posts/2015-01-01-aura-of-purity.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Aura of Purity"
 date:   2015-01-01
-tags: [paladin, level4]
+tags: [paladin, level4, abjuration]
 ---
 
 **4th-level abjuration**

--- a/_posts/2015-01-01-aura-of-vitality.markdown
+++ b/_posts/2015-01-01-aura-of-vitality.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Aura Of Vitality"
 date:   2015-01-01
-tags: [paladin, level3]
+tags: [paladin, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-01-01-banishment.markdown
+++ b/_posts/2015-01-01-banishment.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Banishment"
 date:   2015-01-01
-tags: [cleric, paladin, sorcerer, warlock, wizard, level4]
+tags: [cleric, paladin, sorcerer, warlock, wizard, level4, abjuration]
 ---
 
 **4th-level abjuration**

--- a/_posts/2015-01-01-beacon-of-hope.markdown
+++ b/_posts/2015-01-01-beacon-of-hope.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Beacon of Hope"
 date:   2015-01-01
-tags: [cleric, level3]
+tags: [cleric, level3, abjuration]
 ---
 
 **3rd-level abjuration**

--- a/_posts/2015-01-01-bestow-curse.markdown
+++ b/_posts/2015-01-01-bestow-curse.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Bestow Curse"
 date:   2015-01-01
-tags: [bard, cleric, wizard, level3]
+tags: [bard, cleric, wizard, level3, necromancy]
 ---
 
 **3rd-level necromancy**

--- a/_posts/2015-01-01-blight.markdown
+++ b/_posts/2015-01-01-blight.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Blight"
 date:   2015-01-01
-tags: [druid, sorcerer, warlock, wizard, level4]
+tags: [druid, sorcerer, warlock, wizard, level4, necromancy]
 ---
 
 **4th-level necromancy**

--- a/_posts/2015-01-01-blinding-smite.markdown
+++ b/_posts/2015-01-01-blinding-smite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Blinding Smite"
 date:   2015-01-01
-tags: [paladin, level3]
+tags: [paladin, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-01-01-blink.markdown
+++ b/_posts/2015-01-01-blink.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Blink"
 date:   2015-01-01
-tags: [sorcerer, wizard, level3]
+tags: [sorcerer, wizard, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-01-call-lightning.markdown
+++ b/_posts/2015-01-01-call-lightning.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Call Lightning"
 date:   2015-01-01
-tags: [druid, level3]
+tags: [druid, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-01-clairvoyance.markdown
+++ b/_posts/2015-01-01-clairvoyance.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Clairvoyance"
 date:   2015-01-01
-tags: [bard, cleric, sorcerer, wizard, level3]
+tags: [bard, cleric, sorcerer, wizard, level3, divination]
 ---
 
 **3rd-level divination**

--- a/_posts/2015-01-01-cloud-of-daggers.markdown
+++ b/_posts/2015-01-01-cloud-of-daggers.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Cloud of Daggers"
 date:   2015-01-01
-tags: [bard, sorcerer, warlock, wizard, level2]
+tags: [bard, sorcerer, warlock, wizard, level2, conjuration]
 ---
 
 **2nd-level conjuration**

--- a/_posts/2015-01-01-compulsion.markdown
+++ b/_posts/2015-01-01-compulsion.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Compulsion"
 date:   2015-01-01
-tags: [bard, level4]
+tags: [bard, level4, enchantment]
 ---
 
 **4th-level enchantment**

--- a/_posts/2015-01-01-conjure-animals.markdown
+++ b/_posts/2015-01-01-conjure-animals.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Conjure Animals"
 date:   2015-01-01
-tags: [druid, ranger, level3]
+tags: [druid, ranger, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-01-conjure-barrage.markdown
+++ b/_posts/2015-01-01-conjure-barrage.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Conjure Barrage"
 date:   2015-01-01
-tags: [ranger, level3]
+tags: [ranger, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-01-counterspell.markdown
+++ b/_posts/2015-01-01-counterspell.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Counterspell"
 date:   2015-01-01
-tags: [sorcerer, warlock, wizard, level3]
+tags: [sorcerer, warlock, wizard, level3, abjuration]
 ---
 
 **3rd-level abjuration**

--- a/_posts/2015-01-01-create-food-and-water.markdown
+++ b/_posts/2015-01-01-create-food-and-water.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Create Food and Water"
 date:   2015-01-01
-tags: [cleric, paladin, level3]
+tags: [cleric, paladin, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-01-crusaders-mantle.markdown
+++ b/_posts/2015-01-01-crusaders-mantle.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Crusader's Mantle"
 date:   2015-01-01
-tags: [paladin, level3]
+tags: [paladin, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-01-01-daylight.markdown
+++ b/_posts/2015-01-01-daylight.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Daylight"
 date:   2015-01-01
-tags: [cleric, druid, paladin, ranger, sorcerer, level3]
+tags: [cleric, druid, paladin, ranger, sorcerer, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-01-01-dispel-magic.markdown
+++ b/_posts/2015-01-01-dispel-magic.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Dispel Magic"
 date:   2015-01-01
-tags: [bard, cleric, druid, paladin, sorcerer, warlock, wizard, level3]
+tags: [bard, cleric, druid, paladin, sorcerer, warlock, wizard, level3, abjuration]
 ---
 
 **3rd-level abjuration**

--- a/_posts/2015-01-01-elemental-weapon.markdown
+++ b/_posts/2015-01-01-elemental-weapon.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Elemental Weapon"
 date:   2015-01-01
-tags: [paladin, level3]
+tags: [paladin, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-01-fear.markdown
+++ b/_posts/2015-01-01-fear.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Fear"
 date:   2015-01-01
-tags: [bard, sorcerer, warlock, wizard, level3]
+tags: [bard, sorcerer, warlock, wizard, level3, illusion]
 ---
 
 **3rd-level illusion**

--- a/_posts/2015-01-01-feign-death.markdown
+++ b/_posts/2015-01-01-feign-death.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Feign Death"
 date:   2015-01-01
-tags: [bard, cleric, druid, wizard, level3]
+tags: [bard, cleric, druid, wizard, level3, necromancy]
 ---
 
 **3rd-level necromancy (ritual)**

--- a/_posts/2015-01-01-fireball.markdown
+++ b/_posts/2015-01-01-fireball.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Fireball"
 date:   2015-01-01
-tags: [sorcerer, wizard, level3]
+tags: [sorcerer, wizard, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-01-01-fly.markdown
+++ b/_posts/2015-01-01-fly.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Fly"
 date:   2015-01-01
-tags: [sorcerer, warlock, wizard, level3]
+tags: [sorcerer, warlock, wizard, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-01-gaseous-form.markdown
+++ b/_posts/2015-01-01-gaseous-form.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Gaseous Form"
 date:   2015-01-01
-tags: [sorcerer, wizard, level3]
+tags: [sorcerer, wizard, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-01-haste.markdown
+++ b/_posts/2015-01-01-haste.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Haste"
 date:   2015-01-01
-tags: [sorcerer, wizard, level3]
+tags: [sorcerer, wizard, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-01-hunger-of-hadar.markdown
+++ b/_posts/2015-01-01-hunger-of-hadar.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Hunger of Hadar"
 date:   2015-01-01
-tags: [warlock, level3]
+tags: [warlock, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-01-hypnotic-pattern.markdown
+++ b/_posts/2015-01-01-hypnotic-pattern.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Hypnotic Pattern"
 date:   2015-01-01
-tags: [bard, sorcerer, warlock, wizard, level3]
+tags: [bard, sorcerer, warlock, wizard, level3, illusion]
 ---
 
 **3rd-level illusion**

--- a/_posts/2015-01-01-lightning-arrow.markdown
+++ b/_posts/2015-01-01-lightning-arrow.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Lightning Arrow"
 date:   2015-01-01
-tags: [ranger, level3]
+tags: [ranger, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-01-magic-circle.markdown
+++ b/_posts/2015-01-01-magic-circle.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Magic Circle"
 date:   2015-01-01
-tags: [cleric, paladin, warlock, wizard, level3]
+tags: [cleric, paladin, warlock, wizard, level3, abjuration]
 ---
 
 **3rd-level abjuration**

--- a/_posts/2015-01-01-major-image.markdown
+++ b/_posts/2015-01-01-major-image.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Major Image"
 date:   2015-01-01
-tags: [bard, sorcerer, warlock, wizard, level3]
+tags: [bard, sorcerer, warlock, wizard, level3, illusion]
 ---
 
 **3rd-level illusion**

--- a/_posts/2015-01-01-mass-healing-word.markdown
+++ b/_posts/2015-01-01-mass-healing-word.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Mass Healing Word"
 date:   2015-01-01
-tags: [cleric, level3]
+tags: [cleric, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-01-02-alter-self.markdown
+++ b/_posts/2015-01-02-alter-self.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Alter Self"
 date:   2015-01-2
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-01-02-arcane-lock.markdown
+++ b/_posts/2015-01-02-arcane-lock.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Arcane Lock"
 date:   2015-01-02
-tags: [wizard, level2]
+tags: [wizard, level2, abjuration]
 ---
 
 **2nd-level abjuration**

--- a/_posts/2015-01-02-barkskin.markdown
+++ b/_posts/2015-01-02-barkskin.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Barkskin"
 date:   2015-01-02
-tags: [druid, ranger, level2]
+tags: [druid, ranger, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-01-02-leomunds-tiny-hut.markdown
+++ b/_posts/2015-01-02-leomunds-tiny-hut.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Leomund's Tiny Hut"
 date:   2015-01-01
-tags: [bard, wizard, level3]
+tags: [bard, wizard, level3, evocation]
 ---
 
 **3rd-level evocation (ritual)**

--- a/_posts/2015-01-02-meld-into-stone.markdown
+++ b/_posts/2015-01-02-meld-into-stone.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Meld Into Stone"
 date:   2015-01-02
-tags: [cleric, druid, level3]
+tags: [cleric, druid, level3, transmutation]
 ---
 
 **3rd-level transmutation (ritual)**

--- a/_posts/2015-01-02-nondetection.markdown
+++ b/_posts/2015-01-02-nondetection.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Nondetection"
 date:   2015-01-02
-tags: [bard, cleric, ranger, level3]
+tags: [bard, cleric, ranger, level3, abjuration]
 ---
 
 **3rd-level abjuration**

--- a/_posts/2015-01-02-phantom-steed.markdown
+++ b/_posts/2015-01-02-phantom-steed.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Phantom Steed"
 date:   2015-01-02
-tags: [wizard,level3]
+tags: [wizard,level3, illusion]
 ---
 
 **3rd-level illusion (ritual)**

--- a/_posts/2015-01-02-plant-growth.markdown
+++ b/_posts/2015-01-02-plant-growth.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Plant Growth"
 date:   2015-01-02
-tags: [bard, druid, ranger, level3]
+tags: [bard, druid, ranger, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-02-protection-from-energy.markdown
+++ b/_posts/2015-01-02-protection-from-energy.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Protection from Energy"
 date:   2015-01-02
-tags: [cleric, druid, ranger, sorcerer, wizard, level3]
+tags: [cleric, druid, ranger, sorcerer, wizard, level3, abjuration]
 ---
 
 **3rd-level abjuration**

--- a/_posts/2015-01-02-revivify.markdown
+++ b/_posts/2015-01-02-revivify.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Revivify"
 date:   2015-01-02
-tags: [cleric, paladin, level3]
+tags: [cleric, paladin, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-02-sending.markdown
+++ b/_posts/2015-01-02-sending.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Sending"
 date:   2015-01-02
-tags: [bard, cleric, wizard, level3]
+tags: [bard, cleric, wizard, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-01-02-sleet-storm.markdown
+++ b/_posts/2015-01-02-sleet-storm.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Sleet Storm"
 date:   2015-01-02
-tags: [druid, sorcerer, wizard, level3]
+tags: [druid, sorcerer, wizard, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-02-slow.markdown
+++ b/_posts/2015-01-02-slow.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Slow"
 date:   2015-01-02
-tags: [sorcerer, wizard, level3]
+tags: [sorcerer, wizard, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-02-speak-with-dead.markdown
+++ b/_posts/2015-01-02-speak-with-dead.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Speak with Dead"
 date:   2015-01-02
-tags: [bard, cleric, level3]
+tags: [bard, cleric, level3, necromancy]
 ---
 
 **3rd-level necromancy**

--- a/_posts/2015-01-02-speak-with-plants.markdown
+++ b/_posts/2015-01-02-speak-with-plants.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Speak with Plants"
 date:   2015-01-02
-tags: [bard, druid, ranger, level3]
+tags: [bard, druid, ranger, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-01-02-spirit-guardians.markdown
+++ b/_posts/2015-01-02-spirit-guardians.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Spirit Guardians"
 date:   2015-01-02
-tags: [cleric, level3]
+tags: [cleric, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-02-stinking-cloud.markdown
+++ b/_posts/2015-01-02-stinking-cloud.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Stinking Cloud"
 date:   2015-01-02
-tags: [bard, sorcerer, wizard, level3]
+tags: [bard, sorcerer, wizard, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-01-05-confusion.markdown
+++ b/_posts/2015-01-05-confusion.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Confusion"
 date:   2015-01-05
-tags: [bard, druid, sorcerer, wizard, level4]
+tags: [bard, druid, sorcerer, wizard, level4, enchantment]
 ---
 
 **4th-level enchantment**

--- a/_posts/2015-01-05-conjure-minor-elementals.markdown
+++ b/_posts/2015-01-05-conjure-minor-elementals.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Conjure Minor Elementals"
 date:   2015-01-05
-tags: [druid, wizard, level4]
+tags: [druid, wizard, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-01-05-conjure-woodland-beings.markdown
+++ b/_posts/2015-01-05-conjure-woodland-beings.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Conjure Woodland Beings"
 date:   2015-01-05
-tags: [druid , ranger, level4]
+tags: [druid , ranger, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-01-05-control-water.markdown
+++ b/_posts/2015-01-05-control-water.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Control Water"
 date:   2015-01-05
-tags: [cleric, druid, wizard, level4]
+tags: [cleric, druid, wizard, level4, transmutation]
 ---
 
 **4th-level transmutation**

--- a/_posts/2015-01-05-death-ward.markdown
+++ b/_posts/2015-01-05-death-ward.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Death Ward"
 date:   2015-01-05
-tags: [cleric, paladin, level4]
+tags: [cleric, paladin, level4, abjuration]
 ---
 
 **4th-level abjuration**

--- a/_posts/2015-01-06-tongues.markdown
+++ b/_posts/2015-01-06-tongues.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Tongues"
 date:   2015-01-02
-tags: [bard, cleric, sorcerer, warlock, wizard, level3]
+tags: [bard, cleric, sorcerer, warlock, wizard, level3, divination]
 ---
 
 **3rd-level divination**

--- a/_posts/2015-01-07-beast-sense.markdown
+++ b/_posts/2015-01-07-beast-sense.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Beast Sense"
 date:   2015-01-07
-tags: [druid, ranger, level2]
+tags: [druid, ranger, level2, divination]
 ---
 
 **2nd-level divination (ritual)**

--- a/_posts/2015-01-07-blur.markdown
+++ b/_posts/2015-01-07-blur.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Blur"
 date:   2015-01-07
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, illusion]
 ---
 
 **2nd-level illusion**

--- a/_posts/2015-01-07-branding-smite.markdown
+++ b/_posts/2015-01-07-branding-smite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Branding Smite"
 date:   2015-01-07
-tags: [paladin, level2]
+tags: [paladin, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-01-07-cordon-of-arrows.markdown
+++ b/_posts/2015-01-07-cordon-of-arrows.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Cordon Of Arrows"
 date:   2015-01-07
-tags: [ranger, level2]
+tags: [ranger, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-01-07-crown-of-madness.markdown
+++ b/_posts/2015-01-07-crown-of-madness.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Crown of Madness"
 date:   2015-01-07
-tags: [bard, sorcerer, warlock, wizard, level2]
+tags: [bard, sorcerer, warlock, wizard, level2, enchantment]
 ---
 
 **2nd-level enchantment**

--- a/_posts/2015-01-07-darkness.markdown
+++ b/_posts/2015-01-07-darkness.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Darkness"
 date:   2015-01-07
-tags: [sorcerer, warlock, wizard, level2]
+tags: [sorcerer, warlock, wizard, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-01-07-darkvision.markdown
+++ b/_posts/2015-01-07-darkvision.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Darkvision"
 date:   2015-01-07
-tags: [druid, ranger, sorcerer, wizard, level2]
+tags: [druid, ranger, sorcerer, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-01-07-detect-thoughts.markdown
+++ b/_posts/2015-01-07-detect-thoughts.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Detect Thoughts"
 date:   2015-01-07
-tags: [bard, sorcerer, wizard, level2]
+tags: [bard, sorcerer, wizard, level2, divination]
 ---
 
 **2nd-level divination**

--- a/_posts/2015-01-09-animal-shapes.markdown
+++ b/_posts/2015-01-09-animal-shapes.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Animal Shapes"
 date:   2015-01-09
-tags: [druid, level8]
+tags: [druid, level8, transmutation]
 ---
 
 **8th-level transmutation**

--- a/_posts/2015-01-09-antimagic-field.markdown
+++ b/_posts/2015-01-09-antimagic-field.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Antimagic Field"
 date:   2015-01-09
-tags: [cleric, wizard, level8]
+tags: [cleric, wizard, level8, abjuration]
 ---
 
 **8th-level abjuration**

--- a/_posts/2015-01-10-feeblemind.markdown
+++ b/_posts/2015-01-10-feeblemind.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Feeblemind"
 date: 2015-01-10
-tags: [bard, druid, warlock, wizard, level8]
+tags: [bard, druid, warlock, wizard, level8, enchantment]
 ---
 
 **8th-level enchantment**

--- a/_posts/2015-01-11-dimension-door.markdown
+++ b/_posts/2015-01-11-dimension-door.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Dimension Door"
 date:   2015-01-11
-tags: [bard, sorcerer, warlock, wizard, level4]
+tags: [bard, sorcerer, warlock, wizard, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-01-11-forcecage.markdown
+++ b/_posts/2015-01-11-forcecage.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Forcecage"
 date: 2015-01-11
-tags: [bard, warlock, wizard, level7]
+tags: [bard, warlock, wizard, level7, evocation]
 ---
 
 **7th-level evocation**

--- a/_posts/2015-05-11-suggestion.markdown
+++ b/_posts/2015-05-11-suggestion.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Suggestion"
 date: 2015-05-11
-tags: [bard, sorcerer, warlock, wizard, level2]
+tags: [bard, sorcerer, warlock, wizard, level2, enchantment]
 ---
 
 **2nd-level enchantment**

--- a/_posts/2015-06-07-invisibility.markdown
+++ b/_posts/2015-06-07-invisibility.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Invisibility"
 date: 2015-06-07
-tags: [bard, sorcerer, warlock, wizard, level2]
+tags: [bard, sorcerer, warlock, wizard, level2, illusion]
 ---
 
 **2nd-level illusion**

--- a/_posts/2015-07-14-antilife-shell.markdown
+++ b/_posts/2015-07-14-antilife-shell.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Antilife Shell"
 date: 2015-07-14
-tags: [druid, level5]
+tags: [druid, level5, abjuration]
 ---
 
 **5th-level abjuration**

--- a/_posts/2015-07-14-antilife-shell.md
+++ b/_posts/2015-07-14-antilife-shell.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Antilife Shell"
 date: 2015-07-14
-tags: [druid, level6]
+tags: [druid, level6, abjuration]
 ---
 
 **5th-level abjuration**

--- a/_posts/2015-07-14-arcane-gate.markdown
+++ b/_posts/2015-07-14-arcane-gate.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Arcane Gate"
 date: 2015-07-14
-tags: [sorcerer, warlock, wizard, level6]
+tags: [sorcerer, warlock, wizard, level6, conjuration]
 ---
 
 **6th-level conjuration**

--- a/_posts/2015-07-14-awaken.markdown
+++ b/_posts/2015-07-14-awaken.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Awaken"
 date: 2015-07-14
-tags: [bard, druid, level5]
+tags: [bard, druid, level5, transmutation]
 ---
 
 **5th-level transmutation**

--- a/_posts/2015-07-14-banishing-smite.markdown
+++ b/_posts/2015-07-14-banishing-smite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Banishing Smite"
 date: 2015-07-14
-tags: [paladin, level5]
+tags: [paladin, level5, abjuration]
 ---
 
 **5th-level abjuration**

--- a/_posts/2015-07-14-blade-barrier.markdown
+++ b/_posts/2015-07-14-blade-barrier.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Blade Barrier"
 date: 2015-07-14
-tags: [cleric, level6]
+tags: [cleric, level6, evocation]
 ---
 
 **6th-level evocation**

--- a/_posts/2015-07-14-chain-lightning.markdown
+++ b/_posts/2015-07-14-chain-lightning.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Chain Lightning"
 date: 2015-07-14
-tags: [sorcerer, wizard, level6]
+tags: [sorcerer, wizard, level6, evocation]
 ---
 
 **6th-level evocation**

--- a/_posts/2015-07-14-circle-of-death.markdown
+++ b/_posts/2015-07-14-circle-of-death.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Circle of Death"
 date: 2015-07-14
-tags: [sorcerer, warlock, wizard, level6]
+tags: [sorcerer, warlock, wizard, level6, necromancy]
 ---
 
 **6th-level necromancy**

--- a/_posts/2015-07-14-circle-of-power.markdown
+++ b/_posts/2015-07-14-circle-of-power.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Circle of Power"
 date: 2015-07-14
-tags: [paladin, level5]
+tags: [paladin, level5, abjuration]
 ---
 
 **5th-level abjuration**

--- a/_posts/2015-07-14-cloudkill.markdown
+++ b/_posts/2015-07-14-cloudkill.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Cloudkill"
 date: 2015-07-14
-tags: [sorcerer, wizard, level5]
+tags: [sorcerer, wizard, level5, conjuration]
 ---
 
 **5th-level conjuration**

--- a/_posts/2015-07-14-commune-with-nature.markdown
+++ b/_posts/2015-07-14-commune-with-nature.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Commune with Nature"
 date: 2015-07-14
-tags: [druid, ranger, level5]
+tags: [druid, ranger, level5, divination]
 ---
 
 **5th-level divination (ritual)**

--- a/_posts/2015-07-14-commune.markdown
+++ b/_posts/2015-07-14-commune.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Commune"
 date: 2015-07-14
-tags: [cleric, level5]
+tags: [cleric, level5, divination]
 ---
 
 **5th-level divination (ritual)**

--- a/_posts/2015-07-14-cone-of-cold.markdown
+++ b/_posts/2015-07-14-cone-of-cold.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Cone of Cold"
 date: 2015-07-14
-tags: [sorcerer, wizard, level5]
+tags: [sorcerer, wizard, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-07-14-conjure-elemental.markdown
+++ b/_posts/2015-07-14-conjure-elemental.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Conjure Elemental"
 date: 2015-07-14
-tags: [druid, wizard, level5]
+tags: [druid, wizard, level5, conjuration]
 ---
 
 **5th-level conjuration**

--- a/_posts/2015-07-14-conjure-fey.markdown
+++ b/_posts/2015-07-14-conjure-fey.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Conjure Fey"
 date: 2015-07-14
-tags: [druid, warlock, level6]
+tags: [druid, warlock, level6, conjuration]
 ---
 
 **6th-level conjuration**

--- a/_posts/2015-07-14-conjure-volley.markdown
+++ b/_posts/2015-07-14-conjure-volley.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Conjure Volley"
 date: 2015-07-14
-tags: [ranger, level5]
+tags: [ranger, level5, conjuration]
 ---
 
 **5th-level conjuration**

--- a/_posts/2015-07-14-contact-other-plane.markdown
+++ b/_posts/2015-07-14-contact-other-plane.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Contact Other Plane"
 date: 2015-07-14
-tags: [warlock, wizard, level5]
+tags: [warlock, wizard, level5, divination]
 ---
 
 **5th-level divination (ritual)**

--- a/_posts/2015-07-14-contagion.markdown
+++ b/_posts/2015-07-14-contagion.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Contagion"
 date: 2015-07-14
-tags: [cleric, druid, level5]
+tags: [cleric, druid, level5, necromancy]
 ---
 
 **5th-level necromancy**

--- a/_posts/2015-07-14-contingency.markdown
+++ b/_posts/2015-07-14-contingency.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Contingency"
 date: 2015-07-14
-tags: [wizard, level6]
+tags: [wizard, level6, evocation]
 ---
 
 **6th-level evocation**

--- a/_posts/2015-07-14-continual-flame.markdown
+++ b/_posts/2015-07-14-continual-flame.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Continual Flame"
 date: 2015-07-14
-tags: [cleric, wizard, level2]
+tags: [cleric, wizard, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-07-14-create-undead.markdown
+++ b/_posts/2015-07-14-create-undead.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Create Undead"
 date: 2015-07-14
-tags: [cleric, warlock, wizard, level6]
+tags: [cleric, warlock, wizard, level6, necromancy]
 ---
 
 **6th-level necromancy**

--- a/_posts/2015-07-14-creation.markdown
+++ b/_posts/2015-07-14-creation.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Creation"
 date: 2015-07-14
-tags: [sorcerer, wizard, level5]
+tags: [sorcerer, wizard, level5, illusion]
 ---
 
 **5th-level illusion**

--- a/_posts/2015-07-14-destructive-wave.markdown
+++ b/_posts/2015-07-14-destructive-wave.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Destructive Wave"
 date: 2015-07-14
-tags: [paladin, level5]
+tags: [paladin, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-07-14-disintegrate.markdown
+++ b/_posts/2015-07-14-disintegrate.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Disintegrate"
 date: 2015-07-14
-tags: [sorcerer, wizard, level6]
+tags: [sorcerer, wizard, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-07-14-dispel-evil-and-good.markdown
+++ b/_posts/2015-07-14-dispel-evil-and-good.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Dispel Evil and Good"
 date: 2015-07-14
-tags: [cleric, paladin, level5]
+tags: [cleric, paladin, level5, abjuration]
 ---
 
 **5th-level abjuration**

--- a/_posts/2015-07-14-divination.markdown
+++ b/_posts/2015-07-14-divination.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Divination"
 date: 2015-07-14
-tags: [cleric, level4]
+tags: [cleric, level4, divination]
 ---
 
 **4th-level divination (ritual)**

--- a/_posts/2015-07-14-dominate-beast.markdown
+++ b/_posts/2015-07-14-dominate-beast.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Dominate Beast"
 date: 2015-07-14
-tags: [druid, sorcerer, level4]
+tags: [druid, sorcerer, level4, enchantment]
 ---
 
 **4th-level enchantment**

--- a/_posts/2015-07-14-dominate-person.markdown
+++ b/_posts/2015-07-14-dominate-person.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Dominate Person"
 date: 2015-07-14
-tags: [bard, sorcerer, wizard, level5]
+tags: [bard, sorcerer, wizard, level5, enchantment]
 ---
 
 **5th-level enchantment**

--- a/_posts/2015-07-14-drawmijs-instant-summons.markdown
+++ b/_posts/2015-07-14-drawmijs-instant-summons.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Drawmij's Instant Summons"
 date:   2015-07-14
-tags: [wizard, level6]
+tags: [wizard, level6, conjuration]
 ---
 
 **6th-level conjuration (ritual)**

--- a/_posts/2015-07-14-dream.markdown
+++ b/_posts/2015-07-14-dream.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Dream"
 date: 2015-07-14
-tags: [bard, warlock, wizard, level5]
+tags: [bard, warlock, wizard, level5, illusion]
 ---
 
 **5th-level illusion**

--- a/_posts/2015-07-14-enhance-ability.markdown
+++ b/_posts/2015-07-14-enhance-ability.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Enhance Ability"
 date: 2015-07-14
-tags: [bard, cleric, druid, sorcerer, level2]
+tags: [bard, cleric, druid, sorcerer, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-14-enlarge-reduce.markdown
+++ b/_posts/2015-07-14-enlarge-reduce.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Enlarge/Reduce"
 date: 2015-07-14
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-14-enthrall.markdown
+++ b/_posts/2015-07-14-enthrall.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Enthrall"
 date: 2015-07-14
-tags: [bard, warlock, level2]
+tags: [bard, warlock, level2, enchantment]
 ---
 
 **2nd-level enchantment**

--- a/_posts/2015-07-14-evards-black-tentacles.markdown
+++ b/_posts/2015-07-14-evards-black-tentacles.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Evard's Black Tentacles"
 date:   2015-07-14
-tags: [wizard, level4]
+tags: [wizard, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-07-14-eyebite.markdown
+++ b/_posts/2015-07-14-eyebite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Eyebite"
 date: 2015-07-14
-tags: [bard, sorcerer, warlock, wizard, level6]
+tags: [bard, sorcerer, warlock, wizard, level6, necromancy]
 ---
 
 **6th-level necromancy**

--- a/_posts/2015-07-14-fabricate.markdown
+++ b/_posts/2015-07-14-fabricate.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Fabricate"
 date: 2015-07-14
-tags: [wizard, level4]
+tags: [wizard, level4, transmutation]
 ---
 
 **4th-level transmutation**

--- a/_posts/2015-07-14-find-steed.markdown
+++ b/_posts/2015-07-14-find-steed.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Find Steed"
 date: 2015-07-14
-tags: [paladin, level2]
+tags: [paladin, level2, conjuration]
 ---
 
 **2nd-level conjuration**

--- a/_posts/2015-07-14-find-the-path.markdown
+++ b/_posts/2015-07-14-find-the-path.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Find the Path"
 date: 2015-07-14
-tags: [bard, cleric, druid, level6]
+tags: [bard, cleric, druid, level6, divination]
 ---
 
 **6th-level divination**

--- a/_posts/2015-07-14-find-traps.markdown
+++ b/_posts/2015-07-14-find-traps.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Find Traps"
 date: 2015-07-14
-tags: [cleric, druid, ranger, level2]
+tags: [cleric, druid, ranger, level2, divination]
 ---
 
 **2nd-level divination**

--- a/_posts/2015-07-14-fire-shield.markdown
+++ b/_posts/2015-07-14-fire-shield.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Fire Shield"
 date: 2015-07-14
-tags: [wizard, level4]
+tags: [wizard, level4, evocation]
 ---
 
 **4th-level evocation**

--- a/_posts/2015-07-14-flame-blade.markdown
+++ b/_posts/2015-07-14-flame-blade.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Flame Blade"
 date: 2015-07-14
-tags: [druid, level2]
+tags: [druid, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-07-14-flame-strike.markdown
+++ b/_posts/2015-07-14-flame-strike.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Flame Strike"
 date: 2015-07-14
-tags: [cleric, level5]
+tags: [cleric, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-07-14-flaming-sphere.markdown
+++ b/_posts/2015-07-14-flaming-sphere.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Flaming Sphere"
 date: 2015-07-14
-tags: [druid, wizard, level2]
+tags: [druid, wizard, level2, conjuration]
 ---
 
 **2nd-level conjuration**

--- a/_posts/2015-07-14-flesh-to-stone.markdown
+++ b/_posts/2015-07-14-flesh-to-stone.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Flesh to Stone"
 date: 2015-07-14
-tags: [warlock, wizard, level6]
+tags: [warlock, wizard, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-07-14-forbiddance.markdown
+++ b/_posts/2015-07-14-forbiddance.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Forbiddance"
 date: 2015-07-14
-tags: [cleric, level6]
+tags: [cleric, level6, abjuration]
 ---
 
 **6th-level abjuration (ritual)**

--- a/_posts/2015-07-14-freedom-of-movement.markdown
+++ b/_posts/2015-07-14-freedom-of-movement.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Freedom of Movement"
 date: 2015-07-14
-tags: [bard, cleric, druid, ranger, level4]
+tags: [bard, cleric, druid, ranger, level4, abjuration]
 ---
 
 **4th-level abjuration**

--- a/_posts/2015-07-30-bigbys-hand.markdown
+++ b/_posts/2015-07-30-bigbys-hand.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Bigby's Hand"
 date: 2015-07-30
-tags: [wizard, level5]
+tags: [wizard, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-07-30-geas.markdown
+++ b/_posts/2015-07-30-geas.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Geas"
 date: 2015-07-30
-tags: [cleric, wizard, paladin, druid, bard, level5]
+tags: [cleric, wizard, paladin, druid, bard, level5, enchantment]
 ---
 
 **5th-level enchantment**

--- a/_posts/2015-07-30-gentle-repose.markdown
+++ b/_posts/2015-07-30-gentle-repose.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Gentle Repose"
 date: 2015-07-30
-tags: [cleric, wizard, level2]
+tags: [cleric, wizard, level2, necromancy]
 ---
 
 **2nd-level necromancy (ritual)**

--- a/_posts/2015-07-30-giant-insect.markdown
+++ b/_posts/2015-07-30-giant-insect.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Giant Insect"
 date: 2015-07-30
-tags: [druid, level4]
+tags: [druid, level4, transmutation]
 ---
 
 **4th-level transmutation**

--- a/_posts/2015-07-30-globe-of-invulnerability.markdown
+++ b/_posts/2015-07-30-globe-of-invulnerability.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Globe of Invulnerability"
 date: 2015-07-30
-tags: [sorcerer, wizard, level6]
+tags: [sorcerer, wizard, level6, abjuration]
 ---
 
 **6th-level abjuration**

--- a/_posts/2015-07-30-glyph-of-warding.markdown
+++ b/_posts/2015-07-30-glyph-of-warding.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Glyph of Warding"
 date: 2015-07-30
-tags: [cleric, wizard, bard, level3]
+tags: [cleric, wizard, bard, level3, abjuration]
 ---
 
 **3rd-level abjuration**

--- a/_posts/2015-07-30-grasping-vine.markdown
+++ b/_posts/2015-07-30-grasping-vine.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Grasping Vine"
 date: 2015-07-30
-tags: [ranger, druid, level4]
+tags: [ranger, druid, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-07-30-greater-invisibility.markdown
+++ b/_posts/2015-07-30-greater-invisibility.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Greater Invisibility"
 date: 2015-07-30
-tags: [sorcerer, wizard, bard, level4]
+tags: [sorcerer, wizard, bard, level4, illusion]
 ---
 
 **4th-level illusion**

--- a/_posts/2015-07-30-greater-restoration.markdown
+++ b/_posts/2015-07-30-greater-restoration.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Greater Restoration"
 date: 2015-07-30
-tags: [cleric, druid, bard, level5]
+tags: [cleric, druid, bard, level5, abjuration]
 ---
 
 **5th-level abjuration**

--- a/_posts/2015-07-30-guardian-of-faith.markdown
+++ b/_posts/2015-07-30-guardian-of-faith.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Guardian of Faith"
 date: 2015-07-30
-tags: [cleric, level4]
+tags: [cleric, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-07-30-guards-and-wards.markdown
+++ b/_posts/2015-07-30-guards-and-wards.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Guards and Wards"
 date: 2015-07-30
-tags: [wizard, bard, level6]
+tags: [wizard, bard, level6, abjuration]
 ---
 
 **6th-level abjuration**

--- a/_posts/2015-07-30-gust-of-wind.markdown
+++ b/_posts/2015-07-30-gust-of-wind.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Gust of Wind"
 date: 2015-07-30
-tags: [sorcerer, wizard, druid, level2]
+tags: [sorcerer, wizard, druid, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-07-30-hallow.markdown
+++ b/_posts/2015-07-30-hallow.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Hallow"
 date: 2015-07-30
-tags: [cleric, level5]
+tags: [cleric, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-07-30-hallucinatory-terrain.markdown
+++ b/_posts/2015-07-30-hallucinatory-terrain.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Hallucinatory Terrain"
 date: 2015-07-30
-tags: [bard, druid, warlock, wizard, level4]
+tags: [bard, druid, warlock, wizard, level4, illusion]
 ---
 
 **4th-level illusion**

--- a/_posts/2015-07-30-harm.markdown
+++ b/_posts/2015-07-30-harm.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Harm"
 date: 2015-07-30
-tags: [cleric, level6]
+tags: [cleric, level6, necromancy]
 ---
 
 **6th-level necromancy**

--- a/_posts/2015-07-30-heal.markdown
+++ b/_posts/2015-07-30-heal.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Heal"
 date: 2015-07-30
-tags: [cleric, druid, level6]
+tags: [cleric, druid, level6, evocation]
 ---
 
 **6th-level evocation**

--- a/_posts/2015-07-30-heat-metal.markdown
+++ b/_posts/2015-07-30-heat-metal.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Heat Metal"
 date: 2015-07-30
-tags: [druid, bard, level2]
+tags: [druid, bard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-30-heroes-feast.markdown
+++ b/_posts/2015-07-30-heroes-feast.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Heroes' Feast"
 date: 2015-07-30
-tags: [cleric, druid, level6]
+tags: [cleric, druid, level6, conjuration]
 ---
 
 **6th-level conjuration**

--- a/_posts/2015-07-30-hold-monster.markdown
+++ b/_posts/2015-07-30-hold-monster.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Hold Monster"
 date: 2015-07-30
-tags: [bard, sorcerer, warlock, wizard, level5]
+tags: [bard, sorcerer, warlock, wizard, level5, enchantment]
 ---
 
 **5th-level enchantment**

--- a/_posts/2015-07-30-ice-storm.markdown
+++ b/_posts/2015-07-30-ice-storm.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Ice Storm"
 date: 2015-07-30
-tags: [druid, sorcerer, wizard, level4]
+tags: [druid, sorcerer, wizard, level4, evocation]
 ---
 
 **4th-level evocation**

--- a/_posts/2015-07-30-insect-plague.markdown
+++ b/_posts/2015-07-30-insect-plague.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Insect Plague"
 date: 2015-07-30
-tags: [cleric, druid, sorcerer, level5]
+tags: [cleric, druid, sorcerer, level5, conjuration]
 ---
 
 **5th-level conjuration**

--- a/_posts/2015-07-30-knock.markdown
+++ b/_posts/2015-07-30-knock.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Knock"
 date: 2015-07-30
-tags: [sorcerer, wizard, bard, level2]
+tags: [sorcerer, wizard, bard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-30-legend-lore.markdown
+++ b/_posts/2015-07-30-legend-lore.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Legend Lore"
 date: 2015-07-30
-tags: [cleric, wizard, bard, level5]
+tags: [cleric, wizard, bard, level5, divination]
 ---
 
 **5th-level divination**

--- a/_posts/2015-07-30-leomunds-secret-chest.markdown
+++ b/_posts/2015-07-30-leomunds-secret-chest.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Leomund's Secret Chest"
 date: 2015-07-30
-tags: [wizard, level4]
+tags: [wizard, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-07-30-levitate.markdown
+++ b/_posts/2015-07-30-levitate.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Levitate"
 date: 2015-07-30
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-30-lightning-bolt.markdown
+++ b/_posts/2015-07-30-lightning-bolt.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Lightning Bolt"
 date: 2015-07-30
-tags: [sorcerer, wizard, level3]
+tags: [sorcerer, wizard, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-07-30-locate-animals-or-plants.markdown
+++ b/_posts/2015-07-30-locate-animals-or-plants.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Locate Animals or Plants"
 date: 2015-07-30
-tags: [bard, druid, ranger, level2]
+tags: [bard, druid, ranger, level2, divination]
 ---
 
 **2nd-level divination (ritual)**

--- a/_posts/2015-07-30-locate-creature.markdown
+++ b/_posts/2015-07-30-locate-creature.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Locate Creature"
 date: 2015-07-30
-tags: [bard, cleric, druid, paladin, ranger, wizard, level4]
+tags: [bard, cleric, druid, paladin, ranger, wizard, level4, divination]
 ---
 
 **4th-level divination**

--- a/_posts/2015-07-30-locate-object.markdown
+++ b/_posts/2015-07-30-locate-object.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Locate Object"
 date: 2015-07-30
-tags: [bard, cleric, druid, paladin, ranger, wizard, level2]
+tags: [bard, cleric, druid, paladin, ranger, wizard, level2, divination]
 ---
 
 **2nd-level divination**

--- a/_posts/2015-07-30-magic-jar.markdown
+++ b/_posts/2015-07-30-magic-jar.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Magic Jar"
 date: 2015-07-30
-tags: [wizard, level6]
+tags: [wizard, level6, necromancy]
 ---
 
 **6th-level necromancy**

--- a/_posts/2015-07-30-magic-mouth.markdown
+++ b/_posts/2015-07-30-magic-mouth.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Magic Mouth"
 date: 2015-07-30
-tags: [bard, wizard, level2]
+tags: [bard, wizard, level2, illusion]
 ---
 
 **2nd-level illusion (ritual)**

--- a/_posts/2015-07-30-magic-weapon.markdown
+++ b/_posts/2015-07-30-magic-weapon.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Magic Weapon"
 date: 2015-07-30
-tags: [paladin, wizard, level2]
+tags: [paladin, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-30-mass-cure-wounds.markdown
+++ b/_posts/2015-07-30-mass-cure-wounds.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Mass Cure Wounds"
 date: 2015-07-30
-tags: [bard, cleric, druid, level5]
+tags: [bard, cleric, druid, level5, conjuration]
 ---
 
 **5th-level conjuration**

--- a/_posts/2015-07-30-mass-suggestion.markdown
+++ b/_posts/2015-07-30-mass-suggestion.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Mass Suggestion"
 date: 2015-07-30
-tags: [bard, sorcerer, warlock, wizard, level6]
+tags: [bard, sorcerer, warlock, wizard, level6, enchantment]
 ---
 
 **6th-level enchantment**

--- a/_posts/2015-07-30-melfs-acid-arrow.markdown
+++ b/_posts/2015-07-30-melfs-acid-arrow.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Melf's Acid Arrow"
 date: 2015-07-30
-tags: [wizard, level2]
+tags: [wizard, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-07-30-mirror-image.markdown
+++ b/_posts/2015-07-30-mirror-image.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Mirror Image"
 date: 2015-07-30
-tags: [sorcerer, warlock, wizard, level2]
+tags: [sorcerer, warlock, wizard, level2, illusion]
 ---
 
 **2nd-level illusion**

--- a/_posts/2015-07-30-mislead.markdown
+++ b/_posts/2015-07-30-mislead.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Mislead"
 date: 2015-07-30
-tags: [bard, wizard, level5]
+tags: [bard, wizard, level5, illusion]
 ---
 
 **5th-level illusion**

--- a/_posts/2015-07-30-misty-step.markdown
+++ b/_posts/2015-07-30-misty-step.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Misty Step"
 date: 2015-07-30
-tags: [sorcerer, warlock, wizard, level2]
+tags: [sorcerer, warlock, wizard, level2, conjuration]
 ---
 
 **2nd-level conjuration**

--- a/_posts/2015-07-30-modify-memory.markdown
+++ b/_posts/2015-07-30-modify-memory.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Modify Memory"
 date: 2015-07-30
-tags: [bard, wizard, level5]
+tags: [bard, wizard, level5, enchantment]
 ---
 
 **5th-level enchantment**

--- a/_posts/2015-07-30-moonbeam.markdown
+++ b/_posts/2015-07-30-moonbeam.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Moonbeam"
 date: 2015-07-30
-tags: [druid, level2]
+tags: [druid, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-07-30-mordenkainens-faithful-hound.markdown
+++ b/_posts/2015-07-30-mordenkainens-faithful-hound.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Mordenkainen's Faithful Hound"
 date: 2015-07-30
-tags: [wizard, level4]
+tags: [wizard, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-07-30-mordenkainens-private-sanctum.markdown
+++ b/_posts/2015-07-30-mordenkainens-private-sanctum.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Mordenkainen's Private Sanctum"
 date: 2015-07-30
-tags: [wizard, level4]
+tags: [wizard, level4, abjuration]
 ---
 
 **4th-level abjuration**

--- a/_posts/2015-07-30-move-earth.markdown
+++ b/_posts/2015-07-30-move-earth.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Move Earth"
 date: 2015-07-30
-tags: [druid, sorcerer, wizard, level6]
+tags: [druid, sorcerer, wizard, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-07-30-nystuls-magic-aura.markdown
+++ b/_posts/2015-07-30-nystuls-magic-aura.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Nystul's Magic Aura"
 date: 2015-07-30
-tags: [wizard, level2]
+tags: [wizard, level2, illusion]
 ---
 
 **2nd-level illusion**

--- a/_posts/2015-07-30-otilukes-freezing-sphere.markdown
+++ b/_posts/2015-07-30-otilukes-freezing-sphere.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Otiluke's Freezing Sphere"
 date: 2015-07-30
-tags: [wizard, level6]
+tags: [wizard, level6, evocation]
 ---
 
 **6th-level evocation**

--- a/_posts/2015-07-30-otilukes-resilient-sphere.markdown
+++ b/_posts/2015-07-30-otilukes-resilient-sphere.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Otiluke's Resilient Sphere"
 date: 2015-07-30
-tags: [wizard, level4]
+tags: [wizard, level4, evocation]
 ---
 
 **4th-level evocation**

--- a/_posts/2015-07-30-ottos-irresistible-dance.markdown
+++ b/_posts/2015-07-30-ottos-irresistible-dance.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Otto's Irresistible Dance"
 date: 2015-07-30
-tags: [bard, wizard, level6]
+tags: [bard, wizard, level6, enchantment]
 ---
 
 **6th-level enchantment**

--- a/_posts/2015-07-30-pass-without-trace.markdown
+++ b/_posts/2015-07-30-pass-without-trace.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Pass Without Trace"
 date: 2015-07-30
-tags: [druid, ranger, level2]
+tags: [druid, ranger, level2, abjuration]
 ---
 
 **2nd-level abjuration**

--- a/_posts/2015-07-30-passwall.markdown
+++ b/_posts/2015-07-30-passwall.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Passwall"
 date: 2015-07-30
-tags: [wizard, level5]
+tags: [wizard, level5, transmutation]
 ---
 
 **5th-level transmutation**

--- a/_posts/2015-07-30-phantasmal-force.markdown
+++ b/_posts/2015-07-30-phantasmal-force.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Phantasmal Force"
 date: 2015-07-30
-tags: [bard, sorcerer, wizard, level2]
+tags: [bard, sorcerer, wizard, level2, illusion]
 ---
 
 **2nd-level illusion**

--- a/_posts/2015-07-30-phantasmal-killer.markdown
+++ b/_posts/2015-07-30-phantasmal-killer.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Phantasmal Killer"
 date: 2015-07-30
-tags: [wizard, level4]
+tags: [wizard, level4, illusion]
 ---
 
 **4th-level illusion**

--- a/_posts/2015-07-30-planar-ally.markdown
+++ b/_posts/2015-07-30-planar-ally.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Planar Ally"
 date: 2015-07-30
-tags: [cleric, level6]
+tags: [cleric, level6, conjuration]
 ---
 
 **6th-level conjuration**

--- a/_posts/2015-07-30-planar-binding.markdown
+++ b/_posts/2015-07-30-planar-binding.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Planar Binding"
 date: 2015-07-30
-tags: [bard, cleric, druid, wizard, level5]
+tags: [bard, cleric, druid, wizard, level5, abjuration]
 ---
 
 **5th-level abjuration**

--- a/_posts/2015-07-30-polymorph.markdown
+++ b/_posts/2015-07-30-polymorph.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Polymorph"
 date: 2015-07-30
-tags: [bard, druid, sorcerer, wizard, level4]
+tags: [bard, druid, sorcerer, wizard, level4, transmutation]
 ---
 
 **4th-level transmutation**

--- a/_posts/2015-07-30-programmed-illusion.markdown
+++ b/_posts/2015-07-30-programmed-illusion.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Programmed Illusion"
 date: 2015-07-30
-tags: [bard, wizard, level6]
+tags: [bard, wizard, level6, illusion]
 ---
 
 **6th-level illusion**

--- a/_posts/2015-07-30-protection-from-poison.markdown
+++ b/_posts/2015-07-30-protection-from-poison.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Protection from Poison"
 date: 2015-07-30
-tags: [cleric, ranger, paladin, druid, level2]
+tags: [cleric, ranger, paladin, druid, level2, abjuration]
 ---
 
 **2nd-level abjuration**

--- a/_posts/2015-07-30-raise-dead.markdown
+++ b/_posts/2015-07-30-raise-dead.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Raise Dead"
 date: 2015-07-30
-tags: [cleric, paladin, bard, level5]
+tags: [cleric, paladin, bard, level5, necromancy]
 ---
 
 **5th-level necromancy**

--- a/_posts/2015-07-30-ray-of-enfeeblement.markdown
+++ b/_posts/2015-07-30-ray-of-enfeeblement.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Ray of Enfeeblement"
 date: 2015-07-30
-tags: [warlock, wizard, level2]
+tags: [warlock, wizard, level2, necromancy]
 ---
 
 **2nd-level necromancy**

--- a/_posts/2015-07-30-reincarnate.markdown
+++ b/_posts/2015-07-30-reincarnate.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Reincarnate"
 date: 2015-07-30
-tags: [druid, level5]
+tags: [druid, level5, transmutation]
 ---
 
 **5th-level transmutation**

--- a/_posts/2015-07-30-rope-trick.markdown
+++ b/_posts/2015-07-30-rope-trick.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Rope Trick"
 date: 2015-07-30
-tags: [wizard, level2]
+tags: [wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-30-scorching-ray.markdown
+++ b/_posts/2015-07-30-scorching-ray.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Scorching Ray"
 date: 2015-07-30
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-07-30-scrying.markdown
+++ b/_posts/2015-07-30-scrying.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Scrying"
 date: 2015-07-30
-tags: [bard, cleric, druid, warlock, wizard, level5]
+tags: [bard, cleric, druid, warlock, wizard, level5, divination]
 ---
 
 **5th-level divination**

--- a/_posts/2015-07-30-see-invisibility.markdown
+++ b/_posts/2015-07-30-see-invisibility.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "See Invisibility"
 date: 2015-07-30
-tags: [bard, sorcerer, wizard, level2]
+tags: [bard, sorcerer, wizard, level2, divination]
 ---
 
 **2nd-level divination**

--- a/_posts/2015-07-30-seeming.markdown
+++ b/_posts/2015-07-30-seeming.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Seeming"
 date: 2015-07-30
-tags: [bard, sorcerer, wizard, level5]
+tags: [bard, sorcerer, wizard, level5, illusion]
 ---
 
 **5th-level illusion**

--- a/_posts/2015-07-30-shatter.markdown
+++ b/_posts/2015-07-30-shatter.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Shatter"
 date: 2015-07-30
-tags: [sorcerer, warlock, wizard, level2]
+tags: [sorcerer, warlock, wizard, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-07-30-spider-climb.markdown
+++ b/_posts/2015-07-30-spider-climb.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Spider Climb"
 date: 2015-07-30
-tags: [sorcerer, warlock, wizard, level2]
+tags: [sorcerer, warlock, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-30-spike-growth.markdown
+++ b/_posts/2015-07-30-spike-growth.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Spike Growth"
 date: 2015-07-30
-tags: [druid, ranger, level2]
+tags: [druid, ranger, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-07-30-staggering-smite.markdown
+++ b/_posts/2015-07-30-staggering-smite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Staggering Smite"
 date: 2015-07-30
-tags: [paladin, level4]
+tags: [paladin, level4, evocation]
 ---
 
 **4th-level evocation**

--- a/_posts/2015-07-30-stone-shape.markdown
+++ b/_posts/2015-07-30-stone-shape.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Stone Shape"
 date: 2015-07-30
-tags: [cleric, druid, wizard, level4]
+tags: [cleric, druid, wizard, level4, transmutation]
 ---
 
 **4th-level transmutation**

--- a/_posts/2015-07-30-stoneskin.markdown
+++ b/_posts/2015-07-30-stoneskin.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Stoneskin"
 date: 2015-07-30
-tags: [druid, sorcerer, ranger, wizard, level4]
+tags: [druid, sorcerer, ranger, wizard, level4, abjuration]
 ---
 
 **4th-level abjuration**

--- a/_posts/2015-07-30-sunbeam.markdown
+++ b/_posts/2015-07-30-sunbeam.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Sunbeam"
 date: 2015-07-30
-tags: [druid, sorcerer, wizard, level6]
+tags: [druid, sorcerer, wizard, level6, evocation]
 ---
 
 **6th-level evocation**

--- a/_posts/2015-07-30-swift-quiver.markdown
+++ b/_posts/2015-07-30-swift-quiver.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Swift Quiver"
 date: 2015-07-30
-tags: [ranger, level5]
+tags: [ranger, level5, transmutation]
 ---
 
 **5th-level transmutation**

--- a/_posts/2015-07-30-telekinesis.markdown
+++ b/_posts/2015-07-30-telekinesis.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Telekinesis"
 date: 2015-07-30
-tags: [sorcerer, wizard, level5]
+tags: [sorcerer, wizard, level5, transmutation]
 ---
 
 **5th-level transmutation**

--- a/_posts/2015-07-30-teleportation-circle.markdown
+++ b/_posts/2015-07-30-teleportation-circle.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Teleportation Circle"
 date: 2015-07-30
-tags: [bard, sorcerer, wizard, level5]
+tags: [bard, sorcerer, wizard, level5, conjuration]
 ---
 
 **5th-level conjuration**

--- a/_posts/2015-07-30-transport-via-plants.markdown
+++ b/_posts/2015-07-30-transport-via-plants.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Transport via Plants"
 date: 2015-07-30
-tags: [druid, level6]
+tags: [druid, level6, conjuration]
 ---
 
 **6th-level conjuration**

--- a/_posts/2015-07-30-tree-stride.markdown
+++ b/_posts/2015-07-30-tree-stride.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Tree Stride"
 date: 2015-07-30
-tags: [druid, ranger, level5]
+tags: [druid, ranger, level5, conjuration]
 ---
 
 **5th-level conjuration**

--- a/_posts/2015-07-30-true-seeing.markdown
+++ b/_posts/2015-07-30-true-seeing.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "True Seeing"
 date: 2015-07-30
-tags: [bard, cleric, sorcerer, warlock, wizard, level6]
+tags: [bard, cleric, sorcerer, warlock, wizard, level6, divination]
 ---
 
 **6th-level divination**

--- a/_posts/2015-07-30-vampiric-touch.markdown
+++ b/_posts/2015-07-30-vampiric-touch.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Vampiric Touch"
 date: 2015-07-30
-tags: [warlock, wizard, level3]
+tags: [warlock, wizard, level3, necromancy]
 ---
 
 **3rd-level necromancy**

--- a/_posts/2015-07-30-wall-of-fire.markdown
+++ b/_posts/2015-07-30-wall-of-fire.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Wall of Fire"
 date: 2015-07-30
-tags: [druid, sorcerer, wizard, level4]
+tags: [druid, sorcerer, wizard, level4, evocation]
 ---
 
 **4th-level evocation**

--- a/_posts/2015-07-30-wall-of-force.markdown
+++ b/_posts/2015-07-30-wall-of-force.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Wall of Force"
 date: 2015-07-30
-tags: [wizard, level5]
+tags: [wizard, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-07-30-wall-of-ice.markdown
+++ b/_posts/2015-07-30-wall-of-ice.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Wall of Ice"
 date: 2015-07-30
-tags: [wizard, level6]
+tags: [wizard, level6, evocation]
 ---
 
 **6th-level evocation**

--- a/_posts/2015-07-30-wall-of-stone.markdown
+++ b/_posts/2015-07-30-wall-of-stone.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Wall of Stone"
 date: 2015-07-30
-tags: [druid, sorcerer, wizard, level5]
+tags: [druid, sorcerer, wizard, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-07-30-wall-of-thorns.markdown
+++ b/_posts/2015-07-30-wall-of-thorns.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Wall of Thorns"
 date: 2015-07-30
-tags: [druid, level6]
+tags: [druid, level6, conjuration]
 ---
 
 **6th-level conjuration**

--- a/_posts/2015-07-30-water-breathing.markdown
+++ b/_posts/2015-07-30-water-breathing.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Water Breathing"
 date: 2015-07-30
-tags: [druid, ranger, sorcerer, wizard, level3]
+tags: [druid, ranger, sorcerer, wizard, level3, transmutation]
 ---
 
 **3rd-level transmutation (ritual)**

--- a/_posts/2015-07-30-water-walk.markdown
+++ b/_posts/2015-07-30-water-walk.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Water Walk"
 date: 2015-07-30
-tags: [cleric, druid, ranger, sorcerer, level2]
+tags: [cleric, druid, ranger, sorcerer, level2, transmutation]
 ---
 
 **3rd-level transmutation (ritual)**

--- a/_posts/2015-07-30-web.markdown
+++ b/_posts/2015-07-30-web.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Web"
 date: 2015-07-30
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, conjuration]
 ---
 
 **2nd-level conjuration**

--- a/_posts/2015-07-30-wind-walk.markdown
+++ b/_posts/2015-07-30-wind-walk.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Wind Walk"
 date: 2015-07-30
-tags: [druid, level6]
+tags: [druid, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-07-30-wind-wall.markdown
+++ b/_posts/2015-07-30-wind-wall.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Wind Wall"
 date: 2015-07-30
-tags: [druid, ranger, level3]
+tags: [druid, ranger, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-07-30-word-of-recall.markdown
+++ b/_posts/2015-07-30-word-of-recall.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Word of Recall"
 date: 2015-07-30
-tags: [cleric, level6]
+tags: [cleric, level6, conjuration]
 ---
 
 **6th-level conjuration**

--- a/_posts/2015-07-30-zone-of-truth.markdown
+++ b/_posts/2015-07-30-zone-of-truth.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "Zone of Truth"
 date: 2015-07-30
-tags: [bard, cleric, paladin, level2]
+tags: [bard, cleric, paladin, level2, enchantment]
 ---
 
 **2nd-level enchantment**

--- a/_posts/2015-08-31-earth-tremor.markdown
+++ b/_posts/2015-08-31-earth-tremor.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Earth Tremor"
 date:   2015-08-31
-tags: [bard, druid, sorcerer, wizard, level1]
+tags: [bard, druid, sorcerer, wizard, level1, evocation]
 ---
 
 **1st-level evocation**

--- a/_posts/2015-08-31-pyrotechnics.markdown
+++ b/_posts/2015-08-31-pyrotechnics.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Pyrotechnics"
 date:   2015-08-31
-tags: [bard, sorcerer, wizard, level2]
+tags: [bard, sorcerer, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-08-31-skywrite.markdown
+++ b/_posts/2015-08-31-skywrite.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Skywrite"
 date:   2015-08-31
-tags: [bard, druid, wizard, level2]
+tags: [bard, druid, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation (ritual)**

--- a/_posts/2015-08-31-warding-wind.markdown
+++ b/_posts/2015-08-31-warding-wind.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Warding Wind"
 date:   2015-08-31
-tags: [bard, druid, sorcerer, level2]
+tags: [bard, druid, sorcerer, level2, evocation]
 ---
 
 **2nd level evocation**

--- a/_posts/2015-11-12-absorb-elements.markdown
+++ b/_posts/2015-11-12-absorb-elements.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Absorb Elements"
 date:   2015-11-12
-tags: [druid, ranger, wizard, level1]
+tags: [druid, ranger, wizard, level1, abjuration]
 ---
 
 **1st-level abjuration**

--- a/_posts/2015-11-12-beast-bond.markdown
+++ b/_posts/2015-11-12-beast-bond.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Beast Bond"
 date:   2015-11-12
-tags: [druid, ranger, level1]
+tags: [druid, ranger, level1, divination]
 ---
 
 **1st-level divination**

--- a/_posts/2015-11-12-ice-knife.markdown
+++ b/_posts/2015-11-12-ice-knife.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Ice Knife"
 date:   2015-11-12
-tags: [druid, sorcerer, wizard, level1]
+tags: [druid, sorcerer, wizard, level1, conjuration]
 ---
 
 **1st-level conjuration**

--- a/_posts/2015-11-13-dust-devil.markdown
+++ b/_posts/2015-11-13-dust-devil.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Dust Devil"
 date:   2015-11-13
-tags: [druid, sorcerer, wizard, level2]
+tags: [druid, sorcerer, wizard, level2, conjuration]
 ---
 
 **2nd-level conjuration**

--- a/_posts/2015-11-13-earthbind.markdown
+++ b/_posts/2015-11-13-earthbind.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Earthbind"
 date:   2015-11-13
-tags: [druid, sorcerer, warlock, wizard, level2]
+tags: [druid, sorcerer, warlock, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-11-19-aganazzars-scorcher.markdown
+++ b/_posts/2015-11-19-aganazzars-scorcher.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Aganazzar's Scorcher"
 date:   2015-11-19
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-11-19-bones-of-the-earth.markdown
+++ b/_posts/2015-11-19-bones-of-the-earth.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Bones of the Earth"
 date:   2015-11-19
-tags: [druid, level6]
+tags: [druid, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-11-19-catapult.markdown
+++ b/_posts/2015-11-19-catapult.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Catapult"
 date:   2015-11-19
-tags: [sorcerer, wizard, level1]
+tags: [sorcerer, wizard, level1, transmutation]
 ---
 
 **1st-level transmutation**

--- a/_posts/2015-11-19-control-winds.markdown
+++ b/_posts/2015-11-19-control-winds.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Control Winds"
 date:   2015-11-19
-tags: [druid, sorcerer, wizard, level5]
+tags: [druid, sorcerer, wizard, level5, transmutation]
 ---
 
 **5th-level transmutation**

--- a/_posts/2015-11-19-elemental-bane.markdown
+++ b/_posts/2015-11-19-elemental-bane.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Elemental Bane"
 date:   2015-11-19
-tags: [druid, warlock, wizard, level4]
+tags: [druid, warlock, wizard, level4, transmutation]
 ---
 
 **4th-level transmutation**

--- a/_posts/2015-11-19-erupting-earth.markdown
+++ b/_posts/2015-11-19-erupting-earth.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Erupting Earth"
 date:   2015-11-19
-tags: [druid, sorcerer, wizard, level3]
+tags: [druid, sorcerer, wizard, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-11-19-flame-arrows.markdown
+++ b/_posts/2015-11-19-flame-arrows.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Flame Arrows"
 date:   2015-11-19
-tags: [druid, ranger, sorcerer, wizard, level3]
+tags: [druid, ranger, sorcerer, wizard, level3, transmutation]
 ---
 
 **3rd-level transmutation**

--- a/_posts/2015-11-19-investiture-of-flame.markdown
+++ b/_posts/2015-11-19-investiture-of-flame.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Investiture of Flame"
 date:   2015-11-19
-tags: [druid, sorcerer, warlock, wizard, level6]
+tags: [druid, sorcerer, warlock, wizard, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-11-19-investiture-of-ice.markdown
+++ b/_posts/2015-11-19-investiture-of-ice.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Investiture of Ice"
 date:   2015-11-19
-tags: [druid, sorcerer, warlock, wizard, level6]
+tags: [druid, sorcerer, warlock, wizard, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-11-19-investiture-of-stone.markdown
+++ b/_posts/2015-11-19-investiture-of-stone.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Investiture of Stone"
 date:   2015-11-19
-tags: [druid, sorcerer, warlock, wizard, level6]
+tags: [druid, sorcerer, warlock, wizard, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-11-19-investiture-of-wind.markdown
+++ b/_posts/2015-11-19-investiture-of-wind.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Investiture of Wind"
 date:   2015-11-19
-tags: [druid, sorcerer, warlock, wizard, level6]
+tags: [druid, sorcerer, warlock, wizard, level6, transmutation]
 ---
 
 **6th-level transmutation**

--- a/_posts/2015-11-19-maelstrom.markdown
+++ b/_posts/2015-11-19-maelstrom.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Maelstrom"
 date:   2015-11-19
-tags: [druid, level5]
+tags: [druid, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-11-19-maximilians-earthen-grasp.markdown
+++ b/_posts/2015-11-19-maximilians-earthen-grasp.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Maximilian's Earthen Grasp"
 date:   2015-11-19
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, transmutation]
 ---
 
 **2nd-level transmutation**

--- a/_posts/2015-11-19-primordial-ward.markdown
+++ b/_posts/2015-11-19-primordial-ward.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Primordial Ward"
 date:   2015-11-19
-tags: [druid, level6]
+tags: [druid, level6, abjuration]
 ---
 
 **6th-level abjuration**

--- a/_posts/2015-11-19-snillocs-snowball-swarm.markdown
+++ b/_posts/2015-11-19-snillocs-snowball-swarm.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Snilloc's Snowball Swarm"
 date:   2015-11-19
-tags: [sorcerer, wizard, level2]
+tags: [sorcerer, wizard, level2, evocation]
 ---
 
 **2nd-level evocation**

--- a/_posts/2015-11-19-tidal-wave.markdown
+++ b/_posts/2015-11-19-tidal-wave.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Tidal Wave"
 date:   2015-11-19
-tags: [druid, wizard, level3]
+tags: [druid, wizard, level3, conjuration]
 ---
 
 **3rd-level conjuration**

--- a/_posts/2015-11-19-transmute-rock.markdown
+++ b/_posts/2015-11-19-transmute-rock.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Transmute Rock"
 date:   2015-11-19
-tags: [druid, wizard, level5]
+tags: [druid, wizard, level5, transmutation]
 ---
 
 **5th-level transmutation**

--- a/_posts/2015-11-19-wall-of-water.markdown
+++ b/_posts/2015-11-19-wall-of-water.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Wall of Water"
 date:   2015-11-19
-tags: [druid, sorcerer, wizard, level3]
+tags: [druid, sorcerer, wizard, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-11-19-watery-sphere.markdown
+++ b/_posts/2015-11-19-watery-sphere.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Watery Sphere"
 date:   2015-11-19
-tags: [druid, sorcerer, wizard, level4]
+tags: [druid, sorcerer, wizard, level4, conjuration]
 ---
 
 **4th-level conjuration**

--- a/_posts/2015-11-19-whirlwind.markdown
+++ b/_posts/2015-11-19-whirlwind.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Whirlwind"
 date:   2015-11-19
-tags: [druid, wizard, level7]
+tags: [druid, wizard, level7, evocation]
 ---
 
 **7th-level evocation**

--- a/_posts/2015-11-20-abi-dalzims-horrid-wilting.markdown
+++ b/_posts/2015-11-20-abi-dalzims-horrid-wilting.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Abi Dalzim's Horrid Wilting"
 date:   2015-11-20
-tags: [sorcerer, wizard, level8]
+tags: [sorcerer, wizard, level8, necromancy]
 ---
 
 **8th-level necromancy**

--- a/_posts/2015-11-20-immolation.markdown
+++ b/_posts/2015-11-20-immolation.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Immolation"
 date:   2015-11-20
-tags: [sorcerer, wizard, level5]
+tags: [sorcerer, wizard, level5, evocation]
 ---
 
 **5th-level evocation**

--- a/_posts/2015-11-20-melfs-minute-meteors.markdown
+++ b/_posts/2015-11-20-melfs-minute-meteors.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Melf's Minute Meteors"
 date:   2015-11-20
-tags: [sorcerer, wizard, level3]
+tags: [sorcerer, wizard, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_posts/2015-11-20-storm-sphere.markdown
+++ b/_posts/2015-11-20-storm-sphere.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Storm Sphere"
 date:   2015-11-20
-tags: [sorcerer, wizard, level4]
+tags: [sorcerer, wizard, level4, evocation]
 ---
 
 **4th-level evocation**

--- a/_posts/2015-11-20-vitriolic-sphere.markdown
+++ b/_posts/2015-11-20-vitriolic-sphere.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Vitriolic Sphere"
 date:   2015-11-20
-tags: [sorcerer, wizard, level4]
+tags: [sorcerer, wizard, level4, evocation]
 ---
 
 **4th-level evocation**

--- a/_posts/2015-11-22-wall-of-sand.markdown
+++ b/_posts/2015-11-22-wall-of-sand.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Wall of Sand"
 date:   2015-11-22
-tags: [wizard, level3]
+tags: [wizard, level3, evocation]
 ---
 
 **3rd-level evocation**

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -218,6 +218,20 @@ dl.tag-list {
     }
 }
 
+dl.schools-list {
+    @extend .tag-list;
+    dd {
+
+        a {
+            color: $grey-color-dark;
+            border-radius: 4px;
+        }
+        a.selected {
+            color: $brand-color;
+        }
+    }
+}
+
 .post-list-head{
     font-size: 22px;
     color: $grey-color-dark;

--- a/index.html
+++ b/index.html
@@ -13,6 +13,17 @@ layout: default
     </dd>
     {% endfor %}
   </dl>
+  <dl class="schools-list">
+    <dt>Spell schools:</dt>
+      <dd>
+        <a class="spell-school selected" name="all">All</a>
+      </dd> |
+    {% for spellSchool in site.data.schools %}
+      <dd>
+        <a class="spell-school" name="{{ spellSchool.tag }}">{{ spellSchool.name }}</a>
+      </dd>
+    {% endfor %}
+  </dl>
   {% for level in site.data.levels %}
     <a id="{{level.tag}}"></a>
     <h2 class="post-list-head">{{level.title}}</h2>
@@ -20,7 +31,7 @@ layout: default
       {% assign post_list = site.tags.[{{level.tag}}] | sort: 'title' %}
       {% for post in post_list %}
         <li>
-            <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+            <a class="post-link" tags="{{ post.tags | join " " }}" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION

Early attempt at filtering spells by school of magic (#133). Needs styling and could do with code cleanup but I mainly wanted to get your impression of the UI changes.

![screen shot 2015-12-24 at 3 06 25 pm](https://cloud.githubusercontent.com/assets/1165066/11997678/f80511a6-aa4f-11e5-9377-dfa4f72c48c3.png)

By default the "all" school is selected, which applies no filter to the list. Specific schools of magic can be selected (the selection can be toggled) and the spell list is filtered to show the union of spells matching the selected schools.

I didn't look very closely at jets to see if this could be integrated with the filtering it already provides, but I suppose it's possible to at least mimic it by modifying a custom style tag instead of iterating over the list of spells whenever the school selection changes.