### PR TITLE
wizard not cleric

### DIFF
--- a/_posts/2015-01-02-nondetection.markdown
+++ b/_posts/2015-01-02-nondetection.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Nondetection"
 date:   2015-01-02
-tags: [bard, cleric, ranger, level3]
+tags: [bard, ranger, wizard, level3]
 ---
 
 **3rd-level abjuration**


### PR DESCRIPTION
Non detection is a spell for bard, ranger, and wizard but not cleric.