### PR TITLE
Add "Symbol" to level 7 cleric spell list

### DIFF
--- a/_posts/2015-01-12-symbol.markdown
+++ b/_posts/2015-01-12-symbol.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Symbol"
 date:   2015-01-12
-tags:   [bard, wizard, level7]
+tags:   [bard, wizard, cleric, level7]
 ---
 
 **7th-level abjuration**


### PR DESCRIPTION
It's listed as a cleric l7 spell in the Player's Guide, but isn't tagged "cleric" in Grimoire.