### PR TITLE
Add missing word "initial" to "witch bolt" description

### DIFF
--- a/_posts/2014-08-24-witch-bolt.markdown
+++ b/_posts/2014-08-24-witch-bolt.markdown
@@ -17,4 +17,4 @@ tags: [sorcerer, warlock, wizard, level1]
 
 A beam of crackling, blue energy lances out toward a creature within range, forming a sustained arc of lightning between you and the target. Make a ranged spell attack against that creature. On a hit, the target takes 1d12 lightning damage, and on each of your turns for the duration, you can use your action to deal 1d12 lightning damage to the target automatically. The spell ends if you use your action to do anything else. The spell also ends if the target is ever outside the spell's range or if it has total cover from you.
 
-**At Higher Levels.** When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d12 for each slot level above 1st.
+**At Higher Levels.** When you cast this spell using a spell slot of 2nd level or higher, the initial damage increases by 1d12 for each slot level above 1st.


### PR DESCRIPTION
There's a missing word in this description, which is actually quite important. It changes the spell's damage from magnifying over time to magnifying only on the first turn used.

<img width="501" alt="witch bolt" src="https://cloud.githubusercontent.com/assets/10999109/13552042/455f0b58-e31e-11e5-9646-5d4f7efd8b53.png">
