### PR TITLE
Trivial typo in water walk

### DIFF
--- a/_posts/2015-07-30-water-walk.markdown
+++ b/_posts/2015-07-30-water-walk.markdown
@@ -14,7 +14,7 @@ tags: [cleric, druid, ranger, sorcerer, level3]
 
 **Components**: V, S, M (a piece of cork)
 
-**Duration**: 1 hours
+**Duration**: 1 hour
 
 This spell grants the ability to move across any liquid surface--such as water, acid, mud, snow, quicksand, or lava--as if it were harmless solid ground (creatures crossing molten lava can still take damage from the heat). Up to ten willing creatures you can see within range gain this ability for the duration.
 


### PR DESCRIPTION
"1 hours" should be "1 hour"