### PR TITLE
Correct casting unit for alarm spell

### DIFF
--- a/_posts/2014-08-24-alarm.markdown
+++ b/_posts/2014-08-24-alarm.markdown
@@ -8,7 +8,7 @@ tags: [ranger, wizard, level1]
 
 **1st-level abjuration (ritual)**
 
-**Casting Time**: 1 action
+**Casting Time**: 1 minute
 
 **Range**: 30 feet
 


### PR DESCRIPTION
The page lists the cast time as "1 action", but it is actually "1 minute".