### PR TITLE
Fixed Antilife Shell asymmetry

### DIFF
--- a/_posts/2015-07-14-antilife-shell.markdown
+++ b/_posts/2015-07-14-antilife-shell.markdown
@@ -16,8 +16,8 @@ tags: [druid, level6]
 
 **Duration**: Concentration, up to 1 hour
 
-A shimmering barrier extends out from you in a 10-foot radius and moves with you, remaining centered on you and hedging out creatures other than undead and constructs. The barrier lasts for the duration.
+A shimmering barrier extends out from you in a 10-foot-radius and moves with you, remaining centered on you and hedging out creatures other than undead and constructs. The barrier lasts for the duration.
 
 The barrier prevents an affected creature from passing or reaching through. An affected creature can cast spells or make attacks with ranged or reach weapons through the barrier.
 
-If you move so that an affected creature is forced to pass through the barrier, the spell ends.
+If you move so an affected creature is forced to pass through the barrier, the spell ends.

--- a/_posts/2015-07-14-antilife-shell.markdown
+++ b/_posts/2015-07-14-antilife-shell.markdown
@@ -3,7 +3,7 @@ layout: post
 title: "Antilife Shell"
 date: 2015-07-14
 source: PHB.213
-tags: [druid, level5]
+tags: [druid, level6]
 ---
 
 **5th-level abjuration**


### PR DESCRIPTION
There was some asymmetry in the Antilife Shell post causing it to appear as both a Level 5 and Level 6 spell. I fixed that up and made the two markdown files match. 