### PR TITLE
Use "cursor: pointer" for clickable spell school tags

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -225,6 +225,7 @@ dl.schools-list {
         a {
             color: $grey-color-dark;
             border-radius: 4px;
+            cursor: pointer;
         }
         a.selected {
             color: $brand-color;


### PR DESCRIPTION
Minor styling fix for clickable spell school tags. Previously they had `pointer: copy` because the link tag did not have a href-attribute.